### PR TITLE
crypto: switched node keys back to edwards

### DIFF
--- a/p2p/node_info_test.go
+++ b/p2p/node_info_test.go
@@ -1,7 +1,7 @@
 package p2p
 
 import (
-	"github.com/tendermint/tendermint/crypto/bls12381"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,7 +65,7 @@ func TestNodeInfoValidate(t *testing.T) {
 		{"Good RPCAddress", func(ni *DefaultNodeInfo) { ni.Other.RPCAddress = "0.0.0.0:26657" }, false},
 	}
 
-	nodeKey := NodeKey{PrivKey: bls12381.GenPrivKey()}
+	nodeKey := NodeKey{PrivKey: ed25519.GenPrivKey()}
 	name := "testing"
 
 	// test case passes
@@ -89,8 +89,8 @@ func TestNodeInfoValidate(t *testing.T) {
 
 func TestNodeInfoCompatible(t *testing.T) {
 
-	nodeKey1 := NodeKey{PrivKey: bls12381.GenPrivKey()}
-	nodeKey2 := NodeKey{PrivKey: bls12381.GenPrivKey()}
+	nodeKey1 := NodeKey{PrivKey: ed25519.GenPrivKey()}
+	nodeKey2 := NodeKey{PrivKey: ed25519.GenPrivKey()}
 	name := "testing"
 
 	var newTestChannel byte = 0x2

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -1,7 +1,7 @@
 package p2p
 
 import (
-	"github.com/tendermint/tendermint/crypto/bls12381"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 	"net"
 	"sync"
 	"testing"
@@ -38,7 +38,7 @@ func newMockPeer(ip net.IP) *mockPeer {
 	if ip == nil {
 		ip = net.IP{127, 0, 0, 1}
 	}
-	nodeKey := NodeKey{PrivKey: bls12381.GenPrivKey()}
+	nodeKey := NodeKey{PrivKey: ed25519.GenPrivKey()}
 	return &mockPeer{
 		ip: ip,
 		id: nodeKey.ID(),


### PR DESCRIPTION
## Description

Use ed25519 keys as node_info_key in tests

