### PR TITLE
crypto|p2p|state|types: Rename Pub/PrivKey's TypeIdentifier() and Type()

### DIFF
--- a/crypto/bls12381/bls12381.go
+++ b/crypto/bls12381/bls12381.go
@@ -88,11 +88,11 @@ func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
 	return false
 }
 
-func (privKey PrivKey) TypeIdentifier() string {
+func (privKey PrivKey) Type() string {
 	return KeyType
 }
 
-func (privKey PrivKey) Type() crypto.KeyType {
+func (privKey PrivKey) TypeValue() crypto.KeyType {
 	return crypto.BLS12381
 }
 
@@ -177,12 +177,12 @@ func (pubKey PubKey) String() string {
 	return fmt.Sprintf("PubKeyBLS12381{%X}", []byte(pubKey))
 }
 
-func (pubKey PubKey) TypeIdentifier() string {
-	return KeyType
+func (pubKey PubKey) TypeValue() crypto.KeyType {
+	return crypto.BLS12381
 }
 
-func (pubKey PubKey) Type() crypto.KeyType {
-	return crypto.BLS12381
+func (pubKey PubKey) Type() string {
+	return KeyType
 }
 
 func (pubKey PubKey) Equals(other crypto.PubKey) bool {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -34,8 +34,8 @@ type PubKey interface {
 	Bytes() []byte
 	VerifySignature(msg []byte, sig []byte) bool
 	Equals(PubKey) bool
-	TypeIdentifier() string
-	Type() KeyType
+	Type() string
+	TypeValue() KeyType
 }
 
 type PrivKey interface {
@@ -43,8 +43,8 @@ type PrivKey interface {
 	Sign(msg []byte) ([]byte, error)
 	PubKey() PubKey
 	Equals(PrivKey) bool
-	TypeIdentifier() string
-	Type() KeyType
+	Type() string
+	TypeValue() KeyType
 }
 
 type Symmetric interface {

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -93,11 +93,11 @@ func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
 }
 
 
-func (privKey PrivKey) TypeIdentifier() string {
+func (privKey PrivKey) Type() string {
 	return KeyType
 }
 
-func (privKey PrivKey) Type() crypto.KeyType {
+func (privKey PrivKey) TypeValue() crypto.KeyType {
 	return crypto.Ed25519
 }
 
@@ -164,11 +164,11 @@ func (pubKey PubKey) String() string {
 }
 
 
-func (pubKey PubKey) TypeIdentifier() string {
+func (pubKey PubKey) Type() string {
 	return KeyType
 }
 
-func (pubKey PubKey) Type() crypto.KeyType {
+func (pubKey PubKey) TypeValue() crypto.KeyType {
 	return crypto.Ed25519
 }
 

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -58,11 +58,11 @@ func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
 	return false
 }
 
-func (privKey PrivKey) TypeIdentifier() string {
+func (privKey PrivKey) Type() string {
 	return KeyType
 }
 
-func (privKey PrivKey) Type() crypto.KeyType {
+func (privKey PrivKey) TypeValue() crypto.KeyType {
 	return crypto.Secp256k1
 }
 
@@ -165,11 +165,11 @@ func (pubKey PubKey) String() string {
 	return fmt.Sprintf("PubKeySecp256k1{%X}", pubKey[:])
 }
 
-func (pubKey PubKey) TypeIdentifier() string {
+func (pubKey PubKey) Type() string {
 	return KeyType
 }
 
-func (pubKey PubKey) Type() crypto.KeyType {
+func (pubKey PubKey) TypeValue() crypto.KeyType {
 	return crypto.Secp256k1
 }
 

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -69,11 +69,11 @@ func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
 	return false
 }
 
-func (privKey PrivKey) TypeIdentifier() string {
+func (privKey PrivKey) Type() string {
 	return keyType
 }
 
-func (privKey PrivKey) Type() crypto.KeyType {
+func (privKey PrivKey) TypeValue() crypto.KeyType {
 	return crypto.Sr25519
 }
 

--- a/crypto/sr25519/pubkey.go
+++ b/crypto/sr25519/pubkey.go
@@ -71,10 +71,10 @@ func (pubKey PubKey) Equals(other crypto.PubKey) bool {
 	return false
 }
 
-func (pubKey PubKey) TypeIdentifier() string {
+func (pubKey PubKey) Type() string {
 	return keyType
 }
 
-func (pubKey PubKey) Type() crypto.KeyType {
+func (pubKey PubKey) TypeValue() crypto.KeyType {
 	return crypto.Sr25519
 }

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -51,8 +51,8 @@ func (pk privKeyWithNilPubKey) Bytes() []byte                   { return pk.orig
 func (pk privKeyWithNilPubKey) Sign(msg []byte) ([]byte, error) { return pk.orig.Sign(msg) }
 func (pk privKeyWithNilPubKey) PubKey() crypto.PubKey           { return nil }
 func (pk privKeyWithNilPubKey) Equals(pk2 crypto.PrivKey) bool  { return pk.orig.Equals(pk2) }
-func (pk privKeyWithNilPubKey) TypeIdentifier() string          { return "privKeyWithNilPubKey" }
-func (pk privKeyWithNilPubKey) Type() crypto.KeyType            { return crypto.KeyTypeAny }
+func (pk privKeyWithNilPubKey) Type() string                    { return "privKeyWithNilPubKey" }
+func (pk privKeyWithNilPubKey) TypeValue() crypto.KeyType       { return crypto.KeyTypeAny }
 
 func TestSecretConnectionHandshake(t *testing.T) {
 	fooSecConn, barSecConn := makeSecretConnPair(t)

--- a/state/execution.go
+++ b/state/execution.go
@@ -390,9 +390,9 @@ func validateValidatorUpdates(abciUpdates []abci.ValidatorUpdate,
 			return err
 		}
 
-		if !types.IsValidPubkeyType(params, pk.TypeIdentifier()) {
+		if !types.IsValidPubkeyType(params, pk.Type()) {
 			return fmt.Errorf("validator %v is using pubkey %s, which is unsupported for consensus",
-				valUpdate, pk.TypeIdentifier())
+				valUpdate, pk.Type())
 		}
 	}
 	return nil

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -67,8 +67,8 @@ func (pubKeyBLS) Bytes() []byte                           { return []byte{} }
 func (pubKeyBLS) VerifySignature(msg []byte, sig []byte) bool { return false }
 func (pubKeyBLS) Equals(crypto.PubKey) bool               { return false }
 func (pubKeyBLS) String() string                          { return "" }
-func (pubKeyBLS) TypeIdentifier() string                  { return "pubKeyBLS12381" }
-func (pubKeyBLS) Type() crypto.KeyType                    { return crypto.BLS12381 }
+func (pubKeyBLS) Type() string                            { return "pubKeyBLS12381" }
+func (pubKeyBLS) TypeValue() crypto.KeyType               { return crypto.BLS12381 }
 
 func TestABCIValidatorFromPubKeyAndPower(t *testing.T) {
 	pubkey := bls12381.GenPrivKey().PubKey()


### PR DESCRIPTION
This PR revokes renaming of `Type()` to `TypeIdentifier()` which happened
with the BLS integration. There `crypto.KeyType` was introduced which is
used as return value of `Type()` after the integration. This leads to
`e2e.yml` failure due to toml parser failing down the road because it gets a

`crypto.KeyType` (int64) 

https://github.com/dashevo/tenderdash/blob/26493bbbd86d3a2e9b982d8c9f45323e81c2aea1/test/e2e/runner/setup.go#L320

where it expects a `string`

https://github.com/dashevo/tenderdash/blob/26493bbbd86d3a2e9b982d8c9f45323e81c2aea1/test/e2e/app/config.go#L25

Just renaming it in the following way fixes the issue and should avoid
running into similar issues related to `Type()` usage potentially coming
from later upstream backports:

`TypeIdentifier() string` => `Type() string`
`Type() KeyType` => `TypeValue() KeyType`

