### PR TITLE
ci: install BLS library in lint.yml and bump its go version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,18 +8,70 @@ on:
     branches:
       - master
 jobs:
+  bls-signatures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.15.4"
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get BLS library revision
+        id: bls-revision
+        run: |
+          echo "::set-output name=hash::$(git --git-dir=third_party/bls-signatures/src/.git rev-parse HEAD)"
+        shell: bash
+      - uses: actions/cache@v2
+        id: bls-cache
+        with:
+          path: ~/bls-cache
+          key: ${{ runner.os }}-bls-${{ steps.bls-revision.outputs.hash }}
+      - name: Build BLS library
+        run: make install-bls
+        if: steps.bls-cache.outputs.cache-hit != 'true'
+      - name: Save BLS library
+        run: |
+          mkdir -p ~/bls-cache/include
+          cp -vr /usr/local/include/chiabls ~/bls-cache/include
+          cp -vr /usr/local/include/relic* ~/bls-cache/include
+          cp -v /usr/local/lib/libchiabls.a ~/bls-cache/
+        if: steps.bls-cache.outputs.cache-hit != 'true'
+      - uses: actions/cache@v2.1.2
+        with:
+          path: ~/bls-cache
+          key: ${{ runner.os }}-bls-${{ steps.bls-revision.outputs.hash }}
+        if: steps.bls-cache.outputs.cache-hit != 'true'
+
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    needs: bls-signatures
     timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get BLS library revision
+        id: bls-revision
+        run: |
+          echo "::set-output name=hash::$(git --git-dir=third_party/bls-signatures/src/.git rev-parse HEAD)"
+        shell: bash
       - uses: technote-space/get-diff-action@v4
         with:
           PATTERNS: |
             **/**.go
             go.mod
             go.sum
+      - uses: actions/cache@v2
+        with:
+          path: ~/bls-cache
+          key: ${{ runner.os }}-bls-${{ steps.bls-revision.outputs.hash }}
+      - name: Install BLS library
+        run: |
+          sudo cp -vr ~/bls-cache/include/* /usr/local/include/
+          sudo cp -vr ~/bls-cache/libchiabls.a /usr/local/lib/
       - uses: golangci/golangci-lint-action@v2.2.1
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.15.4"
+          go-version: "^1.15.5"
       - uses: actions/checkout@v2
         with:
           submodules: true


### PR DESCRIPTION
Requires #13  and #14 to pass `lint.yml`

