### PR TITLE
docs: update github issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,10 +30,12 @@ assignees: ''
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
+## ABCI app 
+<!--- name for built-in, URL for self-written if it's publicly available) -->
+
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 * Version used: (use `tenderdash version`)
-* Environment name and version (e.g. Chrome 39, node.js 5.4):
 * Operating System and version (desktop, server, or mobile):
 * Install tools:
 * Link to your project:

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,13 +30,11 @@ assignees: ''
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
-## ABCI app 
-<!--- name for built-in, URL for self-written if it's publicly available) -->
-
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-* Version used: (use `tenderdash version`)
+* Version used: <!--- (use `tenderdash version`) -->
 * Operating System and version (desktop, server, or mobile):
+* ABCI app: <!--- name for built-in, URL for self-written if it's publicly available) -->
 * Install tools:
 * Link to your project:
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,42 +1,44 @@
 ---
-name: Bug Report
-about: Create a report to help us squash bugs!
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
 
 ---
-<!--
-Please fill in as much of the template below as you can.
 
-Be ready for followup questions, and please respond in a timely
-manner. We might ask you to provide additional logs and data (tendermint & app).
--->
+<!--- Provide a general summary of the issue in the Title above -->
 
-**Tendermint version** (use `tendermint version` or `git rev-parse --verify HEAD` if installed from source):
+## Expected Behavior
+<!--- Tell us what should happen -->
 
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
 
-**ABCI app** (name for built-in, URL for self-written if it's publicly available):
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug or discuss what you have tried -->
 
-**Environment**:
-- **OS** (e.g. from /etc/os-release):
-- **Install tools**:
-- **Others**:
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
 
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
-**What happened**:
-
-
-**What you expected to happen**:
-
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used: (use `tenderdash version`)
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop, server, or mobile):
+* Install tools:
+* Link to your project:
 
 **Have you tried the latest version**: yes/no
 
-**How to reproduce it** (as minimally and precisely as possible):
-
-**Logs (paste a small part showing an error (< 10 lines) or link a pastebin, gist, etc. containing more of the log file)**:
-
-**Config (you can paste only the changes you've made)**:
-
-**node command runtime flags**:
-
-**Please provide the output from the `http://<ip>:<port>/dump_consensus_state` RPC endpoint for consensus bugs**
-
-**Anything else we need to know**:
+## Logs 
+<!--- Paste a small part showing an error (< 10 lines) or link a pastebin, gist, etc. containing more of the log file -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,36 +1,27 @@
 ---
-name: Feature Request
-about: Create a proposal to request a feature
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
 
 ---
 
-<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
-v                            ✰  Thanks for opening an issue! ✰    
-v    Before smashing the submit button please review the template.
-v    Word of caution: poorly thought-out proposals may be rejected 
-v                     without deliberation 
-☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+<!--- Provide a general summary of the feature request in the Title above -->
 
-## Summary
+## Expected Behavior
+<!--- A clear and concise description of what you want to happen -->
 
-<!-- Short, concise description of the proposed feature -->
+## Current Behavior
+<!--- Explain the difference from current behavior -->
 
-## Problem Definition
+## Possible Solution
+<!--- Suggest ideas of how to implement the addition or change -->
 
-<!-- Why do we need this feature? 
-What problems may be addressed by introducing this feature?
-What benefits does Tendermint stand to gain by including this feature?
-Are there any disadvantages of including this feature? -->
+## Alternatives Considered
+<!--- A clear and concise description of any alternative solutions or features you've considered -->
 
-## Proposal
+## Additional Context
+<!--- Add any other context or screenshots about the feature request here. -->
 
-<!-- Detailed description of requirements of implementation -->
 
-____
-
-#### For Admin Use
-
-- [ ] Not duplicate issue
-- [ ] Appropriate labels applied
-- [ ] Appropriate contributors tagged
-- [ ] Contributor assigned/self-assigned

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,32 @@
-## Description
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
 
-_Please add a description of the changes that this PR introduces and the files that
-are the most critical to review._ 
+## Issue being fixed or feature implemented
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
 
-Closes: #XXX
 
+## What was done?
+<!--- Describe your changes in detail -->
+
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+
+## Breaking Changes
+<!--- Please describe any breaking changes your code introduces and verify that -->
+<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
+
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added or updated relevant unit/integration/functional/e2e tests
+- [ ] I have made corresponding changes to the documentation
+
+**For repository code-owners and collaborators only**
+- [ ] I have assigned this pull request to a milestone


### PR DESCRIPTION
## Description

This PR updates the GitHub PR and Issue templates so they conform with the templates we use in other repos. Some useful parts of the original Tendermint templates have been included as well.

Closes: #XXX

