### PR TITLE
ci: fix arm64 build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           context: .
           file: ./DOCKER/Dockerfile
-          #platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ build-docker:
 
 # Build linux binary on other platforms
 build-linux:
-	GOOS=linux GOARCH=amd64 $(MAKE) build
+	GOOS=linux $(MAKE) build
 .PHONY: build-linux
 
 build-docker-localnode:

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -24,9 +24,9 @@ VERSION := "$(shell git describe --always)"
 GIT_IMPORT="github.com/dashevo/tenderdash/version"
 
 # Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
+XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
 XC_OS=${XC_OS:-"solaris darwin freebsd linux windows"}
-XC_EXCLUDE=${XC_EXCLUDE:-" darwin/arm solaris/amd64 solaris/386 solaris/arm freebsd/amd64 windows/arm "}
+XC_EXCLUDE=${XC_EXCLUDE:-" darwin/arm solaris/amd64 solaris/386 solaris/arm freebsd/amd64 windows/arm windows/arm64 darwin/arm64 solaris/arm64"}
 
 # Make sure build tools are available.
 make tools


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ARM builds were previously failing with:
```
#18 ERROR: executor failed running [/bin/sh -c make build-linux]: exit code: 2
------
 > [linux/arm64 builder 6/6] RUN make build-linux:
------
Dockerfile:12
--------------------
  10 |     
  11 |     RUN make install-bls
  12 | >>> RUN make build-linux
  13 |     
  14 |     FROM alpine:3.9
--------------------
error: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c make build-linux]: exit code: 2
Error: buildx failed with: error: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c make build-linux]: exit code: 2
```

## What was done?
<!--- Describe your changes in detail -->
Credit to Nathan for finding these fixes!!
- Enable `arm64` arch build target
- Do not explicitly target `amd64` during `make build-linux`
- Enable arm64 arch in CI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On RPi and in CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
