### PR TITLE
feat: add ProposedBlockTimeWindow in a config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -905,6 +905,11 @@ type ConsensusConfig struct {
 	// NOTE: when modifying, make sure to update time_iota_ms genesis parameter
 	TimeoutCommit time.Duration `mapstructure:"timeout_commit"`
 
+	// The proposed block time window is doubling of the value in twice
+	// that means for 10 sec the window will be 20 sec, 10 sec before NOW and 10 sec after
+	// this value is used to validate a block time
+	ProposedBlockTimeWindow time.Duration `mapstructure:"proposed_block_time_window"`
+
 	// Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
 	SkipTimeoutCommit bool `mapstructure:"skip_timeout_commit"`
 	// Don't propose a block if the node is set to the proposer, the block proposal instead
@@ -937,6 +942,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		TimeoutPrecommit:            1000 * time.Millisecond,
 		TimeoutPrecommitDelta:       500 * time.Millisecond,
 		TimeoutCommit:               1000 * time.Millisecond,
+		ProposedBlockTimeWindow:     10 * time.Second,
 		SkipTimeoutCommit:           false,
 		DontAutoPropose:             false,
 		CreateEmptyBlocks:           true,
@@ -1037,6 +1043,9 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	}
 	if cfg.TimeoutCommit < 0 {
 		return errors.New("timeout_commit can't be negative")
+	}
+	if cfg.ProposedBlockTimeWindow < 0 {
+		return errors.New("proposed_block_time can't be negative")
 	}
 	if cfg.CreateEmptyBlocksInterval < 0 {
 		return errors.New("create_empty_blocks_interval can't be negative")

--- a/config/toml.go
+++ b/config/toml.go
@@ -426,6 +426,7 @@ timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
 timeout_commit = "{{ .Consensus.TimeoutCommit }}"
+proposed_block_time_window = "{{ .Consensus.ProposedBlockTimeWindow }}"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1365,7 +1365,7 @@ func (cs *State) defaultDoPrevote(height int64, round int32, allowOldBlocks bool
 
 	// Validate proposal block time
 	if !allowOldBlocks {
-		err = cs.blockExec.ValidateBlockTime(cs.state, cs.ProposalBlock)
+		err = cs.blockExec.ValidateBlockTime(cs.config.ProposedBlockTimeWindow, cs.state, cs.ProposalBlock)
 		if err != nil {
 			// ProposalBlock is invalid, prevote nil.
 			logger.Error("enterPrevote: ProposalBlock time is invalid", "err", err)

--- a/state/execution.go
+++ b/state/execution.go
@@ -181,12 +181,12 @@ func (blockExec *BlockExecutor) ValidateBlockChainLock(state State, block *types
 // If the block is invalid, it returns an error.
 // Validation does not mutate state, but does require historical information from the stateDB,
 // ie. to verify evidence from a validator at an old height.
-func (blockExec *BlockExecutor) ValidateBlockTime(state State, block *types.Block) error {
-	err := validateBlockTime(state, block)
-	if err != nil {
-		return err
-	}
-	return err
+func (blockExec *BlockExecutor) ValidateBlockTime(
+	allowedTimeWindow time.Duration,
+	state State,
+	block *types.Block,
+) error {
+	return validateBlockTime(allowedTimeWindow, state, block)
 }
 
 // ApplyBlock validates the block against the state, executes it against the app,

--- a/state/validation.go
+++ b/state/validation.go
@@ -188,7 +188,7 @@ func validateBlock(state State, block *types.Block) error {
 	return nil
 }
 
-func validateBlockTime(state State, block *types.Block) error {
+func validateBlockTime(allowedTimeWindow time.Duration, state State, block *types.Block) error {
 	if block.Height == state.InitialHeight {
 		afterLast := state.LastBlockTime.Add(5 * time.Second)
 		beforeLast := state.LastBlockTime.Add(-5 * time.Second)
@@ -198,8 +198,8 @@ func validateBlockTime(state State, block *types.Block) error {
 		}
 	} else {
 		// Validate block Time is within a range of current time
-		after := tmtime.Now().Add(20 * time.Second)
-		before := tmtime.Now().Add(-20 * time.Second)
+		after := tmtime.Now().Add(allowedTimeWindow)
+		before := tmtime.Now().Add(-allowedTimeWindow)
 		if block.Time.After(after) || block.Time.Before(before) {
 			return fmt.Errorf("block time %v is out of window [%v, %v]",
 				block.Time, before, after)

--- a/test/maverick/consensus/misbehavior.go
+++ b/test/maverick/consensus/misbehavior.go
@@ -196,7 +196,7 @@ func defaultEnterPrevote(cs *State, height int64, round int32) {
 
 	// Validate proposal block time if we are not proposer
 	if !bytes.Equal(cs.privValidatorProTxHash, cs.ProposalBlock.ProposerProTxHash) {
-		err = cs.blockExec.ValidateBlockTime(cs.state, cs.ProposalBlock)
+		err = cs.blockExec.ValidateBlockTime(cs.config.ProposedBlockTimeWindow, cs.state, cs.ProposalBlock)
 		if err != nil {
 			// ProposalBlock is invalid, prevote nil.
 			logger.Error("enterPrevote: ProposalBlock time is invalid", "err", err)


### PR DESCRIPTION
## Issue being fixed or feature implemented
In order to be able to change a proposed block time window, the hardcoded value was moved in a config file
the validator uses the value from the configuration to create the window borders

## What was done?
* Define `proposed_block_time_window` parameter in a configuration and map this parameter to `ProposedBlockTimeWindow` in a config structure

## How Has This Been Tested?
It is already covered by unit tests

## Breaking Changes
Updated the signature of `ValidateBlockTime` method, added `ProposedBlockTimeWindow` as first argument

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
