### PR TITLE
fix: state sync hangs when trying to retrieve AppHash

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -713,10 +713,16 @@ func (c *Client) lightBlockFromPrimaryAtHeight(ctx context.Context, height int64
 		l, err = c.findNewPrimary(ctx, height, true)
 	}
 
-	if err == nil && height != 0 && l.Height != height {
+	// err was re-evaluated inside switch statement above
+	if err != nil {
+		return l, err
+	}
+
+	if height != 0 && l.Height != height {
 		return l, fmt.Errorf("invalid height received from primary: expected %d, got %d", height, l.Height)
 	}
-	return l, err
+
+	return l, nil
 }
 
 // NOTE: requires a providerMutex lock

--- a/light/client.go
+++ b/light/client.go
@@ -688,31 +688,35 @@ func (c *Client) lightBlockFromPrimaryAtHeight(ctx context.Context, height int64
 	switch err {
 	case nil:
 		// Everything went smoothly. We reset the lightBlockRequests and return the light block
-		return l, nil
 
 	case provider.ErrLightBlockTooOld:
-		// If the block is too check to see if it the same as our current block
+		// If the block is too old check to see if it the same as our current block
 		// If that's the case the chain has most likely stalled and it is most likely the current block
 		// If the block is higher than our current block height then return it.
 		// Otherwise we need to find a new primary
 		if c.latestTrustedBlock != nil && l.Height < c.latestTrustedBlock.Height {
-			return c.findNewPrimary(ctx, false)
+			l, err = c.findNewPrimary(ctx, height, false)
+		} else {
+			err = nil
 		}
-		return l, nil
 
 	case provider.ErrNoResponse, provider.ErrLightBlockNotFound, provider.ErrHeightTooHigh:
 		// we find a new witness to replace the primary
 		c.logger.Debug("error from light block request from primary, replacing...",
-			"error", err, "primary", c.primary)
-		return c.findNewPrimary(ctx, false)
-
+			"error", err)
+		l, err = c.findNewPrimary(ctx, height, false)
 	default:
 		// The light client has most likely received either provider.ErrUnreliableProvider or provider.ErrBadLightBlock
 		// These errors mean that the light client should drop the primary and try with another provider instead
 		c.logger.Error("error from light block request from primary, removing...",
-			"error", err, "primary", c.primary)
-		return c.findNewPrimary(ctx, true)
+			"error", err)
+		l, err = c.findNewPrimary(ctx, height, true)
 	}
+
+	if err == nil && height != 0 && l.Height != height {
+		return l, fmt.Errorf("invalid height received from primary: expected %d, got %d", height, l.Height)
+	}
+	return l, err
 }
 
 // NOTE: requires a providerMutex lock
@@ -739,11 +743,11 @@ type witnessResponse struct {
 	err          error
 }
 
-// findNewPrimary concurrently sends a light block request, promoting the first witness to return
+// findNewPrimary concurrently sends a light block request at some height, promoting the first witness to return
 // a valid light block as the new primary. The remove option indicates whether the primary should be
 // entire removed or just appended to the back of the witnesses list. This method also handles witness
 // errors. If no witness is available, it returns the last error of the witness.
-func (c *Client) findNewPrimary(ctx context.Context, remove bool) (*types.LightBlock, error) {
+func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) (*types.LightBlock, error) {
 	c.providerMutex.Lock()
 	defer c.providerMutex.Unlock()
 
@@ -765,8 +769,7 @@ func (c *Client) findNewPrimary(ctx context.Context, remove bool) (*types.LightB
 		wg.Add(1)
 		go func(witnessIndex int, witnessResponsesC chan witnessResponse) {
 			defer wg.Done()
-
-			lb, err := c.witnesses[witnessIndex].LightBlock(subctx, 0)
+			lb, err := c.witnesses[witnessIndex].LightBlock(subctx, height)
 			witnessResponsesC <- witnessResponse{lb, witnessIndex, err}
 		}(index, witnessResponsesC)
 	}

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -13,11 +13,14 @@ WORKDIR /src/tenderdash
 # Fetch dependencies separately (for layer caching)
 COPY go.mod go.sum ./
 RUN go mod download
+# Install BLS library
+COPY third_party ./third_party
+COPY Makefile *.mk ./
+RUN make install-bls
 
 # Copy Tenderdash source
 COPY . .
-# Install BLS library
-RUN make install-bls
+
 # Build Tenderdash and install into /usr/bin/tenderdash
 RUN make build && cp build/tenderdash /usr/bin/tenderdash
 COPY test/e2e/docker/entrypoint* /usr/bin/


### PR DESCRIPTION
## Issue being fixed or feature implemented

Inside state sync AppHash lookup, we try to download light block for future heights (`height+2`, `height+2`). In some scenarios, this fails (correctly), because this block does not exist yet.

In case of error, error handling in `lightBlockFromPrimaryAtHeight()` assumes the primary is "broken", and tries to find a new primary (`findNewPrimary()`) that will work correctly. Unfortunately, `findNewPrimary()` was trying to retrieve most recent block,
effectively missing the fact that error happened due to height that does not exist yet (eg.  `height+2`).

In effect, `findNewPrimary()` returned most recent block, which in turn was sent to AppHash() and was NOT what was expected.


## What was done?

findNewPrimary() now accepts additional argument, `height`, and tries to find a primary which provides that height.


## How Has This Been Tested?

- [x] executed e2e tests for "rotate"

Further tests will be executed as part of https://github.com/dashevo/tenderdash/pull/157 


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
