### PR TITLE
build: make debugging of e2e docker apps easier

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -84,6 +84,8 @@ func init() {
 
 ### Debugging Failures
 
+#### Logs
+
 If a command or test fails, the runner simply exits with an error message and
 non-zero status code. The testnet is left running with data in the testnet
 directory, and can be inspected with e.g. `docker ps`, `docker logs`, or
@@ -92,6 +94,8 @@ testnet, run `./build/runner -f <manifest> cleanup`.
 
 If the standard `log_level` is not detailed enough (e.g. you want "debug" level
 logging for certain modules), you can change it in the manifest file.
+
+#### PProf
 
 Each node exposes a [pprof](https://golang.org/pkg/runtime/pprof/) server. To
 find out the local port, run `docker port <NODENAME> 6060 | awk -F: '{print
@@ -109,6 +113,39 @@ go tool pprof http://localhost:$PORT/debug/pprof/threadcreate
 go tool pprof http://localhost:$PORT/debug/pprof/block
 go tool pprof http://localhost:$PORT/debug/pprof/mutex
 ```
+
+#### Delve debugger
+
+You can run container binaries using the Delve debugger. 
+To enable Delve, set the `DEBUG` environment variable when setting up the runner:
+
+```bash
+DEBUG=1 ./build/runner -f networks/ci.toml setup
+```
+
+NOTE: Right now, only built-in app is supported (the one using `entrypoint-builtin` script)
+
+Containers expose DLV on ports starting from 40001 upwards.
+
+Example configuration for Visual Studio Code `launch.json`:
+
+```json
+{
+	"name": "E2E Docker 1",
+	"type": "go",
+	"request": "attach",
+	"mode": "remote",
+	"remotePath": "/src/tenderdash",
+	"port": 40001,
+	"host": "127.0.0.1"
+}
+```
+
+For more details, see: 
+
+* [JetBrains configuration](https://blog.jetbrains.com/go/2020/05/06/debugging-a-go-application-inside-a-docker-container/)
+* [Visual Studio Code configuration](https://medium.com/@kaperys/delve-into-docker-d6c92be2f823)
+
 
 ## Enabling IPv6
 

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -10,9 +10,14 @@ RUN apt-get -qq install -y cmake sudo libgmp-dev libleveldb-dev librocksdb-dev >
 ENV TENDERMINT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb
 WORKDIR /src/tenderdash
 
+# Install DLV debugger
+ENV DEBUG ""
+RUN go get github.com/go-delve/delve/cmd/dlv
+
 # Fetch dependencies separately (for layer caching)
 COPY go.mod go.sum ./
 RUN go mod download
+
 # Install BLS library
 COPY third_party ./third_party
 COPY Makefile *.mk ./
@@ -24,8 +29,9 @@ COPY . .
 # Build Tenderdash and install into /usr/bin/tenderdash
 RUN make build && cp build/tenderdash /usr/bin/tenderdash
 COPY test/e2e/docker/entrypoint* /usr/bin/
-RUN cd test/e2e && make maverick && cp build/maverick /usr/bin/maverick
-RUN cd test/e2e && make app && cp build/app /usr/bin/app
+
+RUN cd test/e2e && GOFLAGS='-gcflags="all=-N' make maverick && cp build/maverick /usr/bin/maverick
+RUN cd test/e2e && GOFLAGS='-gcflags="all=-N' make app && cp build/app /usr/bin/app
 
 # Set up runtime directory. We don't use a separate runtime image since we need
 # e.g. leveldb and rocksdb which are already installed in the build image.

--- a/test/e2e/docker/entrypoint-builtin
+++ b/test/e2e/docker/entrypoint-builtin
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
+if [ ! -z "$DEBUG" ] ; then
+    DLV="/go/bin/dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec --continue"
+    SEP="--"
+fi
 
 # Forcibly remove any stray UNIX sockets left behind from previous runs
 rm -rf /var/run/privval.sock /var/run/app.sock
 
-/usr/bin/app /tenderdash/config/app.toml
+set -ex
+
+$DLV /usr/bin/app $SEP /tenderdash/config/app.toml


### PR DESCRIPTION
## Issue being fixed or feature implemented

We need a way to debug Tendermint running inside Docker containers as part of end-to-end (e2e) tests.

See [docs](https://github.com/dashevo/tenderdash/blob/lklimek/e2e-delve/test/e2e/README.md#delve-debugger) for details.

## What was done?

1. Installed delve (dlv) inside e2e Docker container
2. If environment variable DEBUG is set, run tenderdash app inside dlv session

## How Has This Been Tested?

Tested locally using MS Visual Studio Code, with `DEBUG=1 go run ./runner -f networks/dashcore.toml`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
