### PR TITLE
backport p2p fix: potential race condition in p2p reactor and switch

### DIFF
--- a/libs/cmap/cmap.go
+++ b/libs/cmap/cmap.go
@@ -22,6 +22,20 @@ func (cm *CMap) Set(key string, value interface{}) {
 	cm.l.Unlock()
 }
 
+// GetOrSet returns the existing value if present. Othewise, it stores `newValue` and returns it.
+func (cm *CMap) GetOrSet(key string, newValue interface{}) (value interface{}, alreadyExists bool) {
+
+	cm.l.Lock()
+	defer cm.l.Unlock()
+
+	if v, ok := cm.m[key]; ok {
+		return v, true
+	}
+
+	cm.m[key] = newValue
+	return newValue, false
+}
+
 func (cm *CMap) Get(key string) interface{} {
 	cm.l.Lock()
 	val := cm.m[key]

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -343,11 +343,10 @@ func (r *Reactor) receiveRequest(src Peer) error {
 // request out for this peer.
 func (r *Reactor) RequestAddrs(p Peer) {
 	id := string(p.ID())
-	if r.requestsSent.Has(id) {
+	if _, exists := r.requestsSent.GetOrSet(id, struct{}{}); exists {
 		return
 	}
 	r.Logger.Debug("Request addrs", "from", p)
-	r.requestsSent.Set(id, struct{}{})
 	p.Send(PexChannel, mustEncode(&tmp2p.PexRequest{}))
 }
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -381,10 +381,9 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 //  - ie. if we're getting ErrDuplicatePeer we can stop
 //  	because the addrbook got us the peer back already
 func (sw *Switch) reconnectToPeer(addr *NetAddress) {
-	if sw.reconnecting.Has(string(addr.ID)) {
+	if _, exists := sw.reconnecting.GetOrSet(string(addr.ID), addr); exists {
 		return
 	}
-	sw.reconnecting.Set(string(addr.ID), addr)
 	defer sw.reconnecting.Delete(string(addr.ID))
 
 	start := time.Now()


### PR DESCRIPTION
## Issue being fixed or feature implemented

There is a potential race condition in [p2p.Reactor.RequestAddrs()](https://github.com/dashevo/tenderdash/blob/13e5ec3dda71d0cf422c1175ebf2d4a2b54b28e0/p2p/pex/pex_reactor.go#L346-L350) and [p2p.Switch.reconnectToPeer()](https://github.com/dashevo/tenderdash/blob/HEAD/p2p/switch.go#L384-L387).

```go
if r.requestsSent.Has(id) {
   return
}
r.requestsSent.Set(id, struct{}{})
```

If two goroutines enter these functions at the same time, they both can pass the `Has()` check (as it's not set yet), and then, both execute the Set() operation in random order, resulting in a non-deterministic behavior.

## What was done?

Implemented CMap.GetOrSet(), inspired by sync.Map.LoadOrStore(), that checks if value exists, and if not - sets it in an atomic way (eg. within one locking operation).

## How Has This Been Tested?

Run unit tests locally

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
