### PR TITLE
fix: avoid potential race conditions in PersistentKVStoreApplication

### DIFF
--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -453,7 +453,8 @@ func copyValidatorSetUpdate(vsu types.ValidatorSetUpdate) types.ValidatorSetUpda
 	vsu.ValidatorUpdates = make([]types.ValidatorUpdate, 0, len(vsu.ValidatorUpdates))
 	for _, vu := range vsu.ValidatorUpdates {
 		cvu := vu
-		cvu.PubKey = &(*vu.PubKey)
+		pkv := *vu.PubKey
+		cvu.PubKey = &pkv
 		cvu.ProTxHash = append([]byte{}, vu.ProTxHash...)
 		vsu.ValidatorUpdates = append(vsu.ValidatorUpdates, cvu)
 	}

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -448,7 +448,6 @@ func (app *PersistentKVStoreApplication) updateQuorumHash(
 	return types.ResponseDeliverTx{Code: code.CodeTypeOK}
 }
 
-// Copy makes and returns a copy of ValidatorSetUpdate structure
 func copyValidatorSetUpdate(vsu types.ValidatorSetUpdate) types.ValidatorSetUpdate {
 	vsu.QuorumHash = append([]byte{}, vsu.QuorumHash...)
 	vsu.ValidatorUpdates = make([]types.ValidatorUpdate, 0, len(vsu.ValidatorUpdates))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
in order to avoid any risks of race conditions, we have to copy validator-set-update rather than using the pointer to this field at PersistentKVStoreApplication, 'cause it leads to a race condition

## What was done?
<!--- Describe your changes in detail -->
Provided a copy of validator-set-update in ResponseEndBlock rather than a pointer on this field at PersistentKVStoreApplication

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally using TestBlockEvents unit-test, that is reported us about this

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Nothing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
