### PR TITLE
build: github workflows: fix dependabot and code coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,14 @@ updates:
       interval: daily
       time: "11:00"
     open-pull-requests-limit: 10
-  - package-ecosystem: npm
-    directory: "/docs"
-    schedule:
-      interval: daily
-      time: "11:00"
-    open-pull-requests-limit: 10
-    reviewers:
-      - fadeev
+#  - package-ecosystem: npm
+#    directory: "/docs"
+#    schedule:
+#      interval: daily
+#      time: "11:00"
+#    open-pull-requests-limit: 10
+#    reviewers:
+#      - fadeev
   - package-ecosystem: gomod
     directory: "/"
     schedule:
@@ -21,7 +21,8 @@ updates:
       time: "11:00"
     open-pull-requests-limit: 10
     reviewers:
-      - melekes
-      - tessr
+      - shotonoff
+      - lklimek
+      - iammadab
     labels:
-      - T:dependencies
+      - dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,4 @@
+---
 name: Test Coverage
 on:
   pull_request:
@@ -5,6 +6,7 @@ on:
     branches:
       - master
       - release/**
+      - v0.*-dev
 
 jobs:
   bls-signatures:


### PR DESCRIPTION
## Issue being fixed or feature implemented

* dependabot is running on /docs, which we don't maintain atm
* diff coverage is not calculated correctly

## What was done?

* disabled dependabot on /docs
* updated dependabot reviewers
* enabled coverage testing on v0.*-dev


## How Has This Been Tested?

To be tested after merge, no way to test it locally

## Breaking Changes

none


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
