### PR TITLE
e2e: Ability to extract and analyze core dumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ CGO_ENABLED ?= 1
 ifeq (,$(findstring nostrip,$(TENDERMINT_BUILD_OPTIONS)))
   BUILD_FLAGS += -trimpath
   LD_FLAGS += -s -w
+else
+  BUILD_FLAGS += -gcflags=all="-N -l"
+  export GOTRACEBACK = crash
 endif
 
 # handle race

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -174,6 +174,34 @@ For more details, see:
 * [JetBrains configuration](https://blog.jetbrains.com/go/2020/05/06/debugging-a-go-application-inside-a-docker-container/)
 * [Visual Studio Code configuration](https://medium.com/@kaperys/delve-into-docker-d6c92be2f823)
 
+#### Core dumps
+
+To analyze core dumps:
+
+1. Examine [Dockerfile](docker/Dockerfile) to ensure `ENV TENDERMINT_BUILD_OPTIONS`  contains `nostrip` option AND `GOTRACEBACK` is set to `crash`, for example: 
+   
+   ```docker
+	ENV TENDERMINT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb,nostrip
+	ENV GOTRACEBACK=crash
+   ```
+   
+2. Build the container with `make`
+3. On the **host** machine, set the location of core files:
+   
+   ```bash
+   echo /core.%p | sudo tee /proc/sys/kernel/core_pattern
+   ```
+
+4. After the container stops due to panic, you can export its contents and run delve debugger:
+
+	```bash
+	CONTAINER=<container name>
+	docker export -o ${CONTAINER}.tar ${CONTAINER}
+	mkdir ${CONTAINER}
+	cd ${CONTAINER}
+	tar -xf ../${CONTAINER}.tar
+	dlv core ./usr/bin/tenderdash ./core.*
+	```
 
 ## Enabling IPv6
 

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y cmake sudo libgmp-dev libleveldb-dev librocksdb-dev >/dev/null
 
 # Set up build directory /src/tenderdash
-ENV TENDERMINT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb
+ENV TENDERMINT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb,nostrip
 WORKDIR /src/tenderdash
 
 # Install DLV debugger
@@ -30,14 +30,15 @@ COPY . .
 RUN make build && cp build/tenderdash /usr/bin/tenderdash
 COPY test/e2e/docker/entrypoint* /usr/bin/
 
-RUN cd test/e2e && GOFLAGS='-gcflags="all=-N' make maverick && cp build/maverick /usr/bin/maverick
-RUN cd test/e2e && GOFLAGS='-gcflags="all=-N' make app && cp build/app /usr/bin/app
+RUN cd test/e2e && make maverick && cp build/maverick /usr/bin/maverick
+RUN cd test/e2e && make app && cp build/app /usr/bin/app
 
 # Set up runtime directory. We don't use a separate runtime image since we need
 # e.g. leveldb and rocksdb which are already installed in the build image.
 WORKDIR /tenderdash
 VOLUME /tenderdash
 ENV TMHOME=/tenderdash
+ENV GOTRACEBACK=crash
 
 EXPOSE 26656 26657 26660 6060
 ENTRYPOINT ["/usr/bin/entrypoint"]


### PR DESCRIPTION

## Issue being fixed or feature implemented

Ability to extract and analyze core dumps.

## What was done?

1. e2e tests build with `nostrip` option
2. e2e tests run with `GOTRACEBACK=crash`
3. for `nostrip` builds, `-gcflags=all="-N -l"` are added
4. docs

## How Has This Been Tested?

run locally and used to debug issues


## Breaking Changes

none


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
