### PR TITLE
fix(pex): ensure seed at least once connects to another seed

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -44,7 +44,7 @@ const (
 	crawlPeerPeriod = 30 * time.Second
 
 	// try to connect to at least 1 peer every this
-	seedConnectRetryPeriod = 10 * time.Second
+	seedConnectMaxDelayPeriod = 5 * time.Second
 	// limit number of retries to dial other seeds during initialization
 	seedInitMaxAttemptToDial = 12
 
@@ -665,10 +665,13 @@ func (r *Reactor) crawlPeersRoutine() {
 	// If we have any seed nodes, consult them first
 	if len(r.seedAddrs) > 0 {
 		for try := 0; try < seedInitMaxAttemptToDial; try++ {
+			// we sleep a few (random) secs to avoid connection storm when whole network restarts
+			delay := time.Duration(tmrand.Int63n(seedConnectMaxDelayPeriod.Nanoseconds()))
+			time.Sleep(delay)
+
 			if r.dialSeeds() {
 				break
 			}
-			time.Sleep(seedConnectRetryPeriod)
 		}
 	} else {
 		// Do an initial crawl


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improved the fix for "orphaned" seeds (PR #198)

## What was done?

Seed will retry the initial connection to other seeds random interval of 0..5 seconds, until at least one connection is successful or a limit of 12 retries is exhausted.

## How Has This Been Tested?

Run e2e tests locally

## Breaking Changes

none

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
