### PR TITLE
fix: update github e2e hooks to support dashcore testnet

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,12 +81,12 @@ jobs:
         run: make -j2 docker runner
         if: "env.GIT_DIFF != ''"
 
-      - name: Run CI testnet
+      - name: Run CI dashcore testnet
         working-directory: test/e2e
-        run: ./build/runner -f networks/ci.toml
+        run: ./build/runner -f networks/dashcore.toml
         if: "env.GIT_DIFF != ''"
 
-      - name: Emit logs on failure
+      - name: Emit logs on failure for dashcore testnet
         if: ${{ failure() }}
         working-directory: test/e2e
-        run: ./build/runner -f networks/ci.toml logs
+        run: ./build/runner -f networks/dashcore.toml logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: bls-signatures
     timeout-minutes: 15
+    env:
+      FULLNODE_PUBKEY_KEEP: false
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,3 +90,13 @@ jobs:
         if: ${{ failure() }}
         working-directory: test/e2e
         run: ./build/runner -f networks/dashcore.toml logs
+
+      - name: Run CI rotate testnet
+        working-directory: test/e2e
+        run: ./build/runner -f networks/rotate.toml
+        if: "env.GIT_DIFF != ''"
+
+      - name: Emit rotate logs on failure
+        if: ${{ failure() }}
+        working-directory: test/e2e
+        run: ./build/runner -f networks/rotate.toml logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,7 +86,7 @@ jobs:
         run: ./build/runner -f networks/dashcore.toml
         if: "env.GIT_DIFF != ''"
 
-      - name: Emit logs on failure for dashcore testnet
+      - name: Emit dashcore logs on failure
         if: ${{ failure() }}
         working-directory: test/e2e
         run: ./build/runner -f networks/dashcore.toml logs


### PR DESCRIPTION
## Issue being fixed or feature implemented

update github e2e hooks to support dashcore testnet instead of ci.toml

## What was done?

update the hook into .github/e2e.yml

## How Has This Been Tested?

e2e test must pass in github CI

## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
