### PR TITLE
Backport the commit b69ac23fd20bdc00dea00c7c8a69fa66f2e675a9 from v.34.12

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -42,11 +42,13 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [node] \#6059 Validate and complete genesis doc before saving to state store (@silasdavis)
 - [state] \#6067 Batch save state data (@githubsands & @cmwaters)
 - [libs/log] \#6174 Include timestamp (`ts` field; `time.RFC3339Nano` format) in JSON logger output (@melekes)
+- [rpc] [\#6717](https://github.com/tendermint/tendermint/pull/6717) introduce
+  `/genesis_chunked` rpc endpoint for handling large genesis files by chunking them
 
 ### BUG FIXES
 
 - [light] [\#6685](https://github.com/tendermint/tendermint/pull/6685) fix bug
-  with incorrecly handling contexts which occasionally froze state sync.
+  with incorrectly handling contexts that would occasionally freeze state sync. (@cmwaters)
 - [statesync] #6881 improvements to stateprovider logic (@cmwaters)
 - [ABCI] #6873 change client to use multi-reader mutexes (@tychoish)
 - [indexing] #6906 enable the PostgreSQL indexer sink (@creachadair)

--- a/light/client.go
+++ b/light/client.go
@@ -899,14 +899,19 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 				c.witnesses[e.WitnessIndex])
 			return err
 		case errBadWitness:
-			// If witness sent us an invalid header, then remove it. If it didn't
-			// respond or couldn't find the block, then we ignore it and move on to
-			// the next witness.
-			if _, ok := e.Reason.(provider.ErrBadLightBlock); ok {
-				c.logger.Info("Witness sent us invalid header / vals -> removing it",
-					"witness", c.witnesses[e.WitnessIndex], "err", err)
-				witnessesToRemove = append(witnessesToRemove, e.WitnessIndex)
+			// If witness sent us an invalid header, then remove it
+			c.logger.Info("witness sent an invalid light block, removing...",
+				"witness", c.witnesses[e.WitnessIndex],
+				"err", err)
+			witnessesToRemove = append(witnessesToRemove, e.WitnessIndex)
+		default: // benign errors can be ignored with the exception of context errors
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
 			}
+
+			// the witness either didn't respond or didn't have the block. We ignore it.
+			c.logger.Info("error comparing first header with witness. You may want to consider removing the witness",
+				"err", err)
 		}
 
 	}

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -2,6 +2,7 @@ package light_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -317,7 +318,7 @@ func TestClientReplacesPrimaryWithWitnessIfPrimaryIsUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, c.Primary(), deadNode)
-	assert.Equal(t, 1, len(c.Witnesses()))
+	assert.Equal(t, 2, len(c.Witnesses()))
 }
 
 // func TestClient_BackwardsVerification(t *testing.T) {
@@ -592,4 +593,52 @@ func TestClientEnsureValidHeadersAndValSets(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientHandlesContexts(t *testing.T) {
+	p := mockp.New(genMockNode(chainID, 100, 10, bTime))
+	dashCoreMockClient := dashcore.NewMockClient(chainID, llmqType, p.MockPV, true)
+
+	// instantiate the light client with a timeout
+	ctxTimeOut, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	_, err := light.NewClient(
+		ctxTimeOut,
+		chainID,
+		p,
+		[]provider.Provider{p, p},
+		dbs.New(dbm.NewMemDB(), chainID),
+		dashCoreMockClient,
+	)
+	require.Error(t, ctxTimeOut.Err())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	// instantiate the client for real
+	c, err := light.NewClient(
+		ctx,
+		chainID,
+		p,
+		[]provider.Provider{p, p},
+		dbs.New(dbm.NewMemDB(), chainID),
+		dashCoreMockClient,
+	)
+	require.NoError(t, err)
+
+	// verify a block with a timeout
+	ctxTimeOutBlock, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	_, err = c.VerifyLightBlockAtHeight(ctxTimeOutBlock, 101, bTime.Add(100*time.Minute))
+	require.Error(t, ctxTimeOutBlock.Err())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	// verify a block with a cancel
+	ctxCancel, cancel := context.WithCancel(ctx)
+	defer cancel()
+	time.AfterFunc(10*time.Millisecond, cancel)
+	_, err = c.VerifyLightBlockAtHeight(ctxCancel, 101, bTime.Add(100*time.Minute))
+	require.Error(t, ctxCancel.Err())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
 }

--- a/light/provider/mock/deadmock.go
+++ b/light/provider/mock/deadmock.go
@@ -2,13 +2,10 @@ package mock
 
 import (
 	"context"
-	"errors"
 
 	"github.com/tendermint/tendermint/light/provider"
 	"github.com/tendermint/tendermint/types"
 )
-
-var errNoResp = errors.New("no response from provider")
 
 type deadMock struct {
 	chainID string
@@ -24,9 +21,9 @@ func (p *deadMock) ChainID() string { return p.chainID }
 func (p *deadMock) String() string { return "deadMock" }
 
 func (p *deadMock) LightBlock(_ context.Context, height int64) (*types.LightBlock, error) {
-	return nil, errNoResp
+	return nil, provider.ErrNoResponse
 }
 
 func (p *deadMock) ReportEvidence(_ context.Context, ev types.Evidence) error {
-	return errNoResp
+	return provider.ErrNoResponse
 }

--- a/light/provider/mock/mock.go
+++ b/light/provider/mock/mock.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/tendermint/tendermint/light/provider"
 	"github.com/tendermint/tendermint/types"
@@ -67,10 +68,17 @@ func (p *Mock) String() string {
 	return fmt.Sprintf("Mock{headers: %s, vals: %v}", headers.String(), vals.String())
 }
 
-func (p *Mock) LightBlock(_ context.Context, height int64) (*types.LightBlock, error) {
+func (p *Mock) LightBlock(ctx context.Context, height int64) (*types.LightBlock, error) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	var lb *types.LightBlock
+
+	// allocate a window of time for contexts to be canceled
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(10 * time.Millisecond):
+	}
 
 	if height > p.latestHeight {
 		return nil, provider.ErrHeightTooHigh


### PR DESCRIPTION
## Issue being fixed or feature implemented
Backport of the upstream commit "b69ac23fd20bdc00dea00c7c8a69fa66f2e675a9": add case to catch cancelled contexts within the detector

## What was done?
* manually backport the changes from upstream commit b69ac23fd20bdc00dea00c7c8a69fa66f2e675a9
* adapt an unit-test for an implementation of `tenderdash` light client

## How Has This Been Tested?

run unit-test locally

## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
