### PR TITLE
backport(test): persistent KV store DB not closed correctly

### DIFF
--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -56,6 +56,10 @@ func NewPersistentKVStoreApplication(dbDir string) *PersistentKVStoreApplication
 	}
 }
 
+func (app *PersistentKVStoreApplication) Close() error {
+	return app.app.state.db.Close()
+}
+
 func (app *PersistentKVStoreApplication) SetLogger(l log.Logger) {
 	app.logger = l
 }

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -318,7 +318,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 	}
 
 	// Create proxyAppConn connection (consensus, mempool, query)
-	clientCreator := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
+	clientCreator, _ := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
 	proxyApp := proxy.NewAppConns(clientCreator)
 	err = proxyApp.Start()
 	if err != nil {

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	db "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -31,6 +32,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	config := getConfig(t)
 
 	app := kvstore.NewPersistentKVStoreApplication(filepath.Join(config.DBDir(), "wal_generator"))
+	t.Cleanup(func() { require.NoError(t, app.Close()) })
 
 	logger := log.TestingLogger().With("wal_generator", "wal_generator")
 	logger.Info("generating WAL (last height msg excluded)", "numBlocks", numBlocks)

--- a/node/node.go
+++ b/node/node.go
@@ -97,9 +97,10 @@ func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 		return nil, fmt.Errorf("failed to load or gen node key %s: %w", config.NodeKeyFile(), err)
 	}
 
+	appClient, _ := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
 	return NewNode(config,
 		nodeKey,
-		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
+		appClient,
 		DefaultGenesisDocProviderFunc(config),
 		DefaultDBProvider,
 		DefaultMetricsProvider(config.Instrumentation),

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -428,9 +428,11 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
 	require.NoError(t, err)
 
+	appClient, closer := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
+	t.Cleanup(func() { closer.Close() })
 	n, err := NewNode(config,
 		nodeKey,
-		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
+		appClient,
 		DefaultGenesisDocProviderFunc(config),
 		DefaultDBProvider,
 		DefaultMetricsProvider(config.Instrumentation),

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"io"
 
 	abcicli "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/counter"
@@ -69,20 +70,28 @@ func (r *remoteClientCreator) NewABCIClient() (abcicli.Client, error) {
 // DefaultClientCreator returns a default ClientCreator, which will create a
 // local client if addr is one of: 'counter', 'counter_serial', 'kvstore',
 // 'persistent_kvstore' or 'noop', otherwise - a remote client.
-func DefaultClientCreator(addr, transport, dbDir string) ClientCreator {
+//
+// The Closer is a noop except for persistent_kvstore applications,
+// which will clean up the store.
+func DefaultClientCreator(addr, transport, dbDir string) (ClientCreator, io.Closer) {
 	switch addr {
 	case "counter":
-		return NewLocalClientCreator(counter.NewApplication(false))
+		return NewLocalClientCreator(counter.NewApplication(false)), noopCloser{}
 	case "counter_serial":
-		return NewLocalClientCreator(counter.NewApplication(true))
+		return NewLocalClientCreator(counter.NewApplication(true)), noopCloser{}
 	case "kvstore":
-		return NewLocalClientCreator(kvstore.NewApplication())
+		return NewLocalClientCreator(kvstore.NewApplication()), noopCloser{}
 	case "persistent_kvstore":
-		return NewLocalClientCreator(kvstore.NewPersistentKVStoreApplication(dbDir))
+		app := kvstore.NewPersistentKVStoreApplication(dbDir)
+		return NewLocalClientCreator(app), app
 	case "noop":
-		return NewLocalClientCreator(types.NewBaseApplication())
+		return NewLocalClientCreator(types.NewBaseApplication()), noopCloser{}
 	default:
 		mustConnect := false // loop retrying
-		return NewRemoteClientCreator(addr, transport, mustConnect)
+		return NewRemoteClientCreator(addr, transport, mustConnect), noopCloser{}
 	}
 }
+
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }

--- a/rpc/client/main_test.go
+++ b/rpc/client/main_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 
 	// and shut down proper at the end
 	rpctest.StopTendermint(node)
+	app.Close()
 	_ = os.RemoveAll(dir)
 	os.Exit(code)
 }

--- a/test/maverick/consensus/replay_file.go
+++ b/test/maverick/consensus/replay_file.go
@@ -319,7 +319,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 	}
 
 	// Create proxyAppConn connection (consensus, mempool, query)
-	clientCreator := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
+	clientCreator, _ := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
 	proxyApp := proxy.NewAppConns(clientCreator)
 	err = proxyApp.Start()
 	if err != nil {

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -139,9 +139,10 @@ func DefaultNewNode(
 		)
 	}
 
+	appClient, _ := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
 	return NewNode(config,
 		nodeKey,
-		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
+		appClient,
 		DefaultGenesisDocProviderFunc(config),
 		DefaultDBProvider,
 		DefaultMetricsProvider(config.Instrumentation),


### PR DESCRIPTION
## Issue being fixed or feature implemented

Persistent KV store database is not correctly closed at the end of unit test.
This causes, for example, the following command to fail:

```bash
go test ./consensus/ -run TestReactorValidatorSetChanges -race -count 2
```

## What was done?

Backport https://github.com/tendermint/tendermint/pull/6304 and https://github.com/tendermint/tendermint/pull/6311

## How Has This Been Tested?

1.  `go test ./consensus/ -run TestReactorValidatorSetChanges -race -count 2` succeeds
2. Passed tests from ./consensus and ./abci


## Breaking Changes

none


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
