### PR TITLE
docs(e2e): update e2e doc how to keep validators public keys at full node

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -96,7 +96,7 @@ parameter `FULLNODE_PUBKEY_KEEP=true`.
 
 For instance:
 
-```bash
+```sh
 FULLNODE_PUBKEY_KEEP=true make runner/dashcore
 ```
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -82,6 +82,18 @@ func init() {
 }
 ```
 
+### Full-node keys
+
+Since Full nodes do not participate in the consensus process, then keeping validators' public keys also is not required.
+By default, public keys are reset during network generation. However, if you need to keep its, then use this env
+parameter `FULLNODE_PUBKEY_KEEP=true`.
+
+For instance:
+
+```bash
+FULLNODE_PUBKEY_KEEP=true make runner/dashcore
+```
+
 ### Speed up running e2e tests
 
 Running the e2e tests using `make runner {network}` takes time because the

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,6 +30,12 @@ Multiple testnets can be run with the `run-multiple.sh` script:
 ./run-multiple.sh networks/generated/gen-group3-*.toml
 ```
 
+In order to generate network configurations with settings for dash, you have to override a default preset with `dash`.
+
+```sh
+./build/generator -d networks/generated/ -p dash
+```
+
 ## Test Stages
 
 The test runner has the following stages, which can also be executed explicitly by running `./build/runner -f <manifest> <stage>`:


### PR DESCRIPTION
## Issue being fixed or feature implemented

Describe how to keep validators public keys at full node

## What was done?
Update e2e documentation


## How Has This Been Tested?

nothing

## Breaking Changes


nothing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
