### PR TITLE
feat: tool to visualize how votes are propagated over gossip protocol

### DIFF
--- a/cmd/gossipviz/README.md
+++ b/cmd/gossipviz/README.md
@@ -1,0 +1,35 @@
+# GossipViz
+
+## Introduction
+
+GossipViz is a tool to visualize messages sent using the gossip protocol.
+Information is read from (JSON-formatted) logs, including DEBUG logs.
+At this point, only votes are supported.
+
+## Prerequisites
+
+In order to visualize gossip protocol, gather in one file all JSON-formatted debug logs from all Validators.
+In case of end-to-end tests runnning locally, to extract logs you can use a short script, like:
+
+```bash
+LOGFILE=$(mktemp /tmp/gossipviz-in.XXXXXXXX)
+for i in 01 02 03 04 05 06 07 08 09 10 11 12 ; do
+    docker logs validator${i} |grep 'Sending vote message' >> $LOGFILE
+done
+```
+
+## Usage
+
+Basic usage:
+
+```bash
+go run ./cmd/gossipviz vote graph \
+    --in logs-from-all-validators.json \
+    --out votes.svg \
+    --format svg \
+    --height 1023 \
+    --author 721540 \
+    --round 0
+```
+
+The command above will parse all logs from `logs-from-all-validators.json`, find votes at height `1023` and round `0` authored (signed) by node with short proTxHash `721540`. Output will be saved to `votes.svg`.

--- a/cmd/gossipviz/commands/root.go
+++ b/cmd/gossipviz/commands/root.go
@@ -1,0 +1,14 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// RootCmd is the root command for Tendermint core.
+var RootCmd = cobra.Command{
+	Use:   "gossipviz",
+	Short: "Visualize tenderdash gossip protocol operations",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
+		return nil
+	},
+}

--- a/cmd/gossipviz/commands/vote.go
+++ b/cmd/gossipviz/commands/vote.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/cmd/gossipviz/logparser"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// VoteCmd generatas main cobra command for the Vote object
+func VoteCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "vote",
+		Short: "Visualize votes gossip",
+	}
+
+	cmd.AddCommand((&voteGraphCommand{}).command())
+	return &cmd
+}
+
+type voteGraphCommand struct {
+	inputFile    string
+	outputFile   string
+	outputFormat string
+	filter       logparser.Filter
+}
+
+func (v *voteGraphCommand) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "graph",
+		PreRunE: v.preRunE,
+		RunE:    v.runE,
+	}
+	v.addFlags(cmd)
+	return cmd
+}
+
+func (v *voteGraphCommand) addFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&v.inputFile, "in", "", "Input file to use instead of stdin")
+	cmd.Flags().StringVar(&v.outputFile, "out", "", "Output file to save rendered graph; required")
+	cmd.Flags().StringVarP(&v.outputFormat, "format", "f", "", "Output format to use, one of: svg (default), png")
+	cmd.Flags().Int64Var(&v.filter.Height, "height", -1, "Limit graph to provided height")
+	cmd.Flags().Int64Var(&v.filter.Round, "round", -1, "Limit graph to provided round")
+	cmd.Flags().StringVar(&v.filter.AuthorProTxHash, "author", "", "Filter by vote author proTxHash")
+
+}
+
+func (v *voteGraphCommand) preRunE(cmd *cobra.Command, args []string) error {
+	return v.validateParams()
+}
+
+func (v *voteGraphCommand) validateParams() error {
+	if v.inputFile != "" {
+		if _, err := os.Stat(v.inputFile); err != nil {
+			return fmt.Errorf("invalid input file %s: %w", v.inputFile, err)
+		}
+	}
+
+	if v.outputFile == "" {
+		return fmt.Errorf("please provide output file with --out")
+	}
+
+	if v.outputFormat == "" {
+		v.outputFormat = logparser.FormatSVG
+	}
+	if v.outputFormat != logparser.FormatSVG && v.outputFormat != logparser.FormatPNG {
+		return fmt.Errorf("invalid format %s, use one of: %s, %s", v.outputFormat, logparser.FormatPNG, logparser.FormatSVG)
+	}
+
+	return nil
+}
+
+func (v *voteGraphCommand) runE(cmd *cobra.Command, args []string) error {
+	logger := log.NewTMLogger(os.Stderr)
+	input := os.Stdin
+	if v.inputFile != "" {
+		f, err := os.Open(v.inputFile)
+		if err != nil {
+			return fmt.Errorf("cannot open file %s: %w", v.inputFile, err)
+		}
+		defer f.Close()
+		input = f
+	}
+
+	logger.Info("Processing vote logs",
+		"input", v.inputFile,
+		"filters", v.filter,
+	)
+
+	graph, err := logparser.NewGraph(logger)
+	if err != nil {
+		return err
+	}
+
+	logProcessor, err := logparser.NewLogProcessor(input, logger, graph)
+	if err != nil {
+		return err
+	}
+	logProcessor.AddParser(logparser.NewVoteParser(v.filter))
+	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
+	defer cancel()
+	if err := logProcessor.Run(ctx); err != nil {
+		return err
+	}
+
+	if v.filter.AuthorProTxHash != "" {
+		if err := graph.ColorNode(v.filter.AuthorProTxHash); err != nil {
+			logger.Debug("cannot set author node color", "node", v.filter.AuthorProTxHash, "error", err)
+		}
+	}
+
+	logger.Info("Rendering image", "output", v.outputFile, "outputFormat", v.outputFormat)
+	if err := graph.Save(v.outputFile, v.outputFormat); err != nil {
+		return err
+	}
+
+	logger.Info("Done", "logStats", logProcessor.Stats(), "graphStats", graph.Stats())
+
+	return nil
+}

--- a/cmd/gossipviz/logparser/filter.go
+++ b/cmd/gossipviz/logparser/filter.go
@@ -1,0 +1,30 @@
+package logparser
+
+import "fmt"
+
+// Filter defines filtering criteria for logs
+type Filter struct {
+	Height          int64
+	Round           int64
+	AuthorProTxHash string
+}
+
+// check checks if the provided log item passes the filter
+func (f Filter) check(item logItem) bool {
+	if f.Height != -1 && f.Height != item.Height {
+		return false
+	}
+	if f.Round != -1 && f.Round != item.Round {
+		return false
+	}
+	if f.AuthorProTxHash != "" && f.AuthorProTxHash != item.AuthorProTxHash {
+		return false
+	}
+
+	return true
+}
+
+// String shows human-readable info about this filter
+func (f Filter) String() string {
+	return fmt.Sprintf("height: %d, round: %d, author proTxHash: %s", f.Height, f.Round, f.AuthorProTxHash)
+}

--- a/cmd/gossipviz/logparser/graph.go
+++ b/cmd/gossipviz/logparser/graph.go
@@ -1,0 +1,117 @@
+// TODO move somewhere
+package logparser
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-graphviz"
+	"github.com/goccy/go-graphviz/cgraph"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+const (
+	// FormatPNG represents PNG format of output
+	FormatPNG = "png"
+	// FormatSVG represents SVG format of output
+	FormatSVG = "svg"
+)
+
+// Graph does all the hard work required to visualize vote flow within the network
+type Graph struct {
+	graphViz *graphviz.Graphviz
+	graph    *cgraph.Graph
+	logger   log.Logger
+}
+
+// NewGraph initializes graph visualization mechanism
+func NewGraph(logger log.Logger) (Graph, error) {
+	var err error
+	graph := Graph{
+		logger:   logger,
+		graphViz: graphviz.New(),
+	}
+
+	if graph.graph, err = graph.graphViz.Graph(); err != nil {
+		return graph, err
+	}
+	graph.graph.SetConcentrate(false)
+	return graph, nil
+}
+
+// getOrAddNode creates a node if it does not exist yet
+func (g *Graph) getOrAddNode(proTxHash string) (*cgraph.Node, error) {
+	node, err := g.graph.Node(proTxHash)
+	if err != nil {
+		return nil, err
+	}
+	if node == nil {
+		node, err = g.graph.CreateNode(proTxHash)
+	}
+	return node, err
+}
+
+// getOrAddNode creates an edge if it does not exist yet
+func (g *Graph) getOrAddEdge(label string, src, dst *cgraph.Node) (*cgraph.Edge, error) {
+	edge, err := g.graph.CreateEdge(label, src, dst)
+	if err != nil {
+		return nil, err
+	}
+	edge.SetDir(cgraph.ForwardDir)
+	edge.SetLabel(label)
+	return edge, nil
+}
+
+// Add adds nodes `src` and `dst`, and connects them with an edge with label `label`
+func (g *Graph) Add(src, dst, label string) error {
+	srcNode, err := g.getOrAddNode(src)
+	if err != nil {
+		return err
+	}
+	dstNode, err := g.getOrAddNode(dst)
+	if err != nil {
+		return err
+	}
+	_, err = g.getOrAddEdge(label, srcNode, dstNode)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Save renders the graph and saves it to a file
+func (g *Graph) Save(filePath string, format string) error {
+	var imgFormat graphviz.Format
+	switch format {
+	case FormatPNG:
+		imgFormat = graphviz.PNG
+	case FormatSVG:
+		imgFormat = graphviz.SVG
+	default:
+		return fmt.Errorf("invalid format %s", format)
+	}
+
+	return g.graphViz.RenderFilename(g.graph, imgFormat, filePath)
+}
+
+// Stats returns some statistics about the graph: number of nodes, number of edges
+func (g *Graph) Stats() string {
+	nodes := g.graph.NumberNodes()
+	edges := g.graph.NumberEdges()
+	return fmt.Sprintf("nodes: %d, edges: %d", nodes, edges)
+}
+
+// ColorNode colors the provided node
+func (g *Graph) ColorNode(name string) error {
+	n, err := g.graph.Node(name)
+	if err != nil {
+		return err
+	}
+	if n == nil {
+		return fmt.Errorf("node %s not found", name)
+	}
+	n.SetStyle(cgraph.FilledNodeStyle)
+	n.SetColor("darkgreen")
+	n.SetFillColor("green")
+	return nil
+}

--- a/cmd/gossipviz/logparser/logitem.go
+++ b/cmd/gossipviz/logparser/logitem.go
@@ -1,0 +1,19 @@
+package logparser
+
+import "time"
+
+type logItem struct {
+	// Timestamp       string `json:"ts"`
+	Timestamp       time.Time `json:"ts"`
+	Msg             string    `json:"_msg"`
+	ProTxHash       string    `json:"proTxHash"`
+	PeerProTxHash   string    `json:"peer_proTxHash"`
+	AuthorProTxHash string    `json:"val_proTxHash"`
+	Height          int64
+	Round           int64
+}
+
+// Time returns string representing the "time" part of the log item timestamp (hour/min/sec/msec)
+func (l logItem) Time() string {
+	return l.Timestamp.Format("15:04:05.999")
+}

--- a/cmd/gossipviz/logparser/logprocessor.go
+++ b/cmd/gossipviz/logparser/logprocessor.go
@@ -61,7 +61,7 @@ func (g *LogProcessor) Run(ctx context.Context) error {
 					continue // non-fatal, try another parser
 				}
 
-				if err := g.graph.Add(src, dst, label); err != nil {
+				if err := g.graph.Add(src, dst, label, item.Timestamp); err != nil {
 					g.logger.Error("error adding item to the graph", "error", err)
 					return err // fatal
 				}

--- a/cmd/gossipviz/logparser/logprocessor.go
+++ b/cmd/gossipviz/logparser/logprocessor.go
@@ -1,0 +1,82 @@
+package logparser
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/rand"
+)
+
+// LogProcessor does all the hard work required to parse logs and visualize vote flow within the network
+type LogProcessor struct {
+	decoder  *json.Decoder
+	graph    Graph
+	logger   log.Logger
+	parsers  []Parser
+	logCount int64
+	hitCount int64
+	errCount int64
+}
+
+// NewLogProcessor creates a new log processor
+func NewLogProcessor(input io.Reader, logger log.Logger, graph Graph) (LogProcessor, error) {
+	parser := LogProcessor{
+		decoder: json.NewDecoder(input),
+		logger:  logger,
+		graph:   graph,
+	}
+	return parser, nil
+}
+
+// AddParser adds new log parser that will interpret the log as it arrives
+func (g *LogProcessor) AddParser(p Parser) {
+	g.parsers = append(g.parsers, p)
+}
+
+// Run is the main processing logic that reads data from input, parses it and adds to graph
+func (g *LogProcessor) Run(ctx context.Context) error {
+	for {
+		item := logItem{}
+		if err := g.decoder.Decode(&item); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if rand.Intn(10000000) == 1 {
+				g.logger.Debug("error parsing item", "error", err)
+			}
+			continue // we ignore errors
+		}
+
+		g.logCount++
+		for _, p := range g.parsers {
+			if p.Check(item) {
+				src, dst, label, err := p.Parse(item)
+				if err != nil {
+					g.logger.Error("error parsing item", "error", err)
+					g.errCount++
+					continue // non-fatal, try another parser
+				}
+
+				if err := g.graph.Add(src, dst, label); err != nil {
+					g.logger.Error("error adding item to the graph", "error", err)
+					return err // fatal
+				}
+				g.hitCount++
+			}
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("execution expired")
+			default:
+			}
+		}
+	}
+}
+
+// Stats return some interesting statistics about log processing
+func (g *LogProcessor) Stats() string {
+	return fmt.Sprintf("processed: %d, hits: %d, errors: %d", g.logCount, g.hitCount, g.errCount)
+}

--- a/cmd/gossipviz/logparser/parser.go
+++ b/cmd/gossipviz/logparser/parser.go
@@ -1,0 +1,9 @@
+package logparser
+
+// Parser represents chunk of code that parse logs to get info required for rendering of a graph
+type Parser interface {
+	// Check checks if the parser can parse provided log item
+	Check(logItem) bool
+	// Parse parses log item and retreieves src and dst node, and label of the edge between them
+	Parse(item logItem) (src string, dst string, label string, err error)
+}

--- a/cmd/gossipviz/logparser/voteparser.go
+++ b/cmd/gossipviz/logparser/voteparser.go
@@ -1,0 +1,34 @@
+package logparser
+
+import (
+	"fmt"
+)
+
+const msgSendingVote = "Sending vote message"
+
+// VoteParser parses "Sending vote message" logs to build graph showing how votes
+// travel through the gossip protocol
+type VoteParser struct {
+	filter Filter
+}
+
+// NewVoteParser defines new vote parser that is used to interpret "Sending vote message"
+func NewVoteParser(f Filter) Parser {
+	return &VoteParser{
+		filter: f,
+	}
+}
+
+// Check implements Parser
+func (v VoteParser) Check(item logItem) bool {
+	if item.Msg != msgSendingVote {
+		return false
+	}
+	return v.filter.check(item)
+}
+
+// Parse implements Parser
+func (v VoteParser) Parse(item logItem) (src string, dst string, label string, err error) {
+	label = fmt.Sprintf("%s\n(H:%d/R:%d)\n%s", item.AuthorProTxHash, item.Height, item.Round, item.Time())
+	return item.ProTxHash, item.PeerProTxHash, label, nil
+}

--- a/cmd/gossipviz/main.go
+++ b/cmd/gossipviz/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+
+	cmd "github.com/tendermint/tendermint/cmd/gossipviz/commands"
+	"github.com/tendermint/tendermint/libs/cli"
+)
+
+func main() {
+	rootCmd := cmd.RootCmd
+	rootCmd.AddCommand(cmd.VoteCmd())
+
+	cmd := cli.PrepareBaseCmd(&rootCmd, "TM", os.ExpandEnv("$HOME"))
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
+}

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1151,7 +1151,14 @@ func (ps *PeerState) SendCommit(commit *types.Commit) bool {
 func (ps *PeerState) PickSendVote(votes types.VoteSetReader) bool {
 	if vote, ok := ps.PickVoteToSend(votes); ok {
 		msg := &VoteMessage{vote}
-		ps.logger.Debug("Sending vote message", "ps", ps, "vote", vote)
+		ps.logger.Debug("Sending vote message",
+			"ps", ps,
+			"peer_proTxHash", ps.peer.NodeInfo().GetProTxHash().ShortString(),
+			"vote", vote,
+			"val_proTxHash", vote.ValidatorProTxHash.ShortString(),
+			"height", vote.Height,
+			"round", vote.Round,
+		)
 		if ps.peer.Send(VoteChannel, MustEncode(msg)) {
 			ps.SetHasVote(vote, nil)
 			return true

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1
 	github.com/go-pkgz/jrpc v0.2.0
 	github.com/go-pkgz/rest v1.11.0 // indirect
+	github.com/goccy/go-graphviz v0.0.9 // indirect
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/btree v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/corona10/goimagehash v1.0.2/go.mod h1:/l9umBhvcHQXVtQO1V6Gp1yD20STawkhRnnX0D1bvVI=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -208,6 +209,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
+github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20210519012713-85d372ac71e2/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
@@ -252,12 +255,15 @@ github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEK
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/goccy/go-graphviz v0.0.9 h1:s/FMMJ1Joj6La3S5ApO3Jk2cwM4LpXECC2muFx3IPQQ=
+github.com/goccy/go-graphviz v0.0.9/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -491,6 +497,7 @@ github.com/nats-io/nats.go v1.12.1/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/
 github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -706,6 +713,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -731,6 +739,8 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20200119044424-58c23975cae1 h1:5h3ngYt7+vXCDZCup/HkCQgW5XwmSvR/nA2JmJ0RErg=
+golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/node/node.go
+++ b/node/node.go
@@ -862,6 +862,9 @@ func NewNode(config *cfg.Config,
 	// Create the handshaker, which calls RequestInfo, sets the AppVersion on the state,
 	// and replays any blocks as necessary to sync tenderdash with the app.
 	consensusLogger := logger.With("module", "consensus")
+	if proTxHashP != nil {
+		consensusLogger = consensusLogger.With("proTxHash", proTxHashP.ShortString())
+	}
 	proposedAppVersion := uint64(0)
 	if !stateSync {
 		handshaker := cs.NewHandshaker(

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -282,6 +282,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.StateSync.DiscoveryTime = 5 * time.Second
 	cfg.Consensus.AppHashSize = crypto.DefaultAppHashSize
 	cfg.BaseConfig.LogLevel = "debug"
+	cfg.BaseConfig.LogFormat = config.LogFormatJSON
 
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:


### PR DESCRIPTION
## Issue being fixed or feature implemented

We need a way to see how the Votes are sent between 


## What was done?

1. Implemented a CLI tool in cli/tenderviz that can parse the logs and generate a graph depicting how votes are gossiped within the network.
2. Improved logging to add details needed by tenderviz

## How Has This Been Tested?

Run manually, using output from e2e tests

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
