### PR TITLE
fix(selectpeers): add fallback for less than 5 validators

### DIFF
--- a/dash/quorum/selectpeers/dip6.go
+++ b/dash/quorum/selectpeers/dip6.go
@@ -1,5 +1,5 @@
-// Package selectpeers is package contains algorithm that selects peers based on the deterministic connection selection algorithm
-// described in DIP-6
+// Package selectpeers is package contains algorithm that selects peers based on the deterministic connection
+// selection algorithm described in DIP-6
 package selectpeers
 
 import (
@@ -10,6 +10,10 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
+// minValidators is a minimum number of validators needed in order to execute the selection
+// algorithm. For less than this number, we connect to all validators.
+const minValidators = 5
+
 // DIP6 selects validators from the `validatorSetMembers`, based on algorithm
 // described in DIP-6 https://github.com/dashpay/dips/blob/master/dip-0006.md
 func DIP6(
@@ -17,6 +21,9 @@ func DIP6(
 	me *types.Validator,
 	quorumHash tmbytes.HexBytes,
 ) ([]*types.Validator, error) {
+	if len(validatorSetMembers) < 2 {
+		return nil, fmt.Errorf("not enough validators: got %d, need 2", len(validatorSetMembers))
+	}
 	// Build the deterministic list of quorum members:
 	// 1. Retrieve the deterministic masternode list which is valid at quorumHeight
 	// 2. Calculate SHA256(proTxHash, quorumHash) for each entry in the list
@@ -25,20 +32,30 @@ func DIP6(
 
 	// Loop through the list until the member finds itself in the list. The index at which it finds itself is called i.
 	meSortable := newSortableValidator(*me, quorumHash)
-	i := float64(sortedValidators.index(meSortable))
-	if i < 0 {
+	myIndex := sortedValidators.index(meSortable)
+	if myIndex < 0 {
 		return []*types.Validator{}, fmt.Errorf("current node is not a member of provided validator set")
+	}
+
+	// Fallback if we don't have enough validators, we connect to all of them
+	if sortedValidators.Len() < minValidators {
+		ret := make([]*types.Validator, 0, len(validatorSetMembers)-1)
+		// We connect to all validators
+		for index, val := range sortedValidators {
+			if index != myIndex {
+				ret = append(ret, val.Copy())
+			}
+		}
+		return ret, nil
 	}
 
 	// Calculate indexes (i+2^k)%n where k is in the range 0..floor(log2(n-1))-1
 	// and n is equal to the size of the list.
 	n := float64(sortedValidators.Len())
 	count := math.Floor(math.Log2(n-1.0)) - 1.0
-	if int(count) <= 0 {
 
-		return []*types.Validator{}, fmt.Errorf("not enough validators: got %d, need at least %d", int(n), 5)
-	}
 	ret := make([]*types.Validator, 0, int(count))
+	i := float64(myIndex)
 	for k := float64(0); k <= count; k++ {
 		index := int(math.Mod(i+math.Pow(2, k), n))
 		// Add addresses of masternodes at indexes calculated at previous step

--- a/dash/quorum/selectpeers/dip6_test.go
+++ b/dash/quorum/selectpeers/dip6_test.go
@@ -32,11 +32,12 @@ func TestDIP6(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "4 validators",
-			validators: mock.NewValidators(4),
-			me:         mock.NewValidator(0),
-			quorumHash: mock.NewQuorumHash(0),
-			wantErr:    true,
+			name:            "4 validators",
+			validators:      mock.NewValidators(4),
+			me:              mock.NewValidator(0),
+			quorumHash:      mock.NewQuorumHash(0),
+			wantLen:         3,
+			wantProTxHashes: mock.NewProTxHashes(0x01, 0x02, 0x03),
 		},
 		{
 			name:            "5 validators",

--- a/dash/quorum/validator_conn_executor_test.go
+++ b/dash/quorum/validator_conn_executor_test.go
@@ -115,7 +115,9 @@ func TestValidatorConnExecutor_Myself(t *testing.T) {
 					mock.NewValidator(2),
 					mock.NewValidator(3),
 				},
-				expectedHistory: []mock.SwitchHistoryEvent{},
+				expectedHistory: []mock.SwitchHistoryEvent{
+					{Operation: mock.OpDialMany},
+				},
 			},
 			1: {
 				validators: []*types.Validator{
@@ -126,9 +128,11 @@ func TestValidatorConnExecutor_Myself(t *testing.T) {
 					mock.NewValidator(4),
 					mock.NewValidator(5),
 				},
-				expectedHistory: []mock.SwitchHistoryEvent{{
-					Operation: mock.OpDialMany,
-				}},
+				expectedHistory: []mock.SwitchHistoryEvent{
+					{Operation: mock.OpStopOne},
+					{Operation: mock.OpStopOne},
+					{Operation: mock.OpDialMany},
+				},
 			},
 			2: {
 				validators: []*types.Validator{me},
@@ -230,9 +234,16 @@ func TestValidatorConnExecutor_ValidatorUpdatesSequence(t *testing.T) {
 				expectedHistory: []mock.SwitchHistoryEvent{
 					0: {Operation: mock.OpStopOne},
 					1: {Operation: mock.OpStopOne},
+					2: {Operation: mock.OpDialMany, Params: []string{mock.NewNodeAddress(1)}},
 				},
 			},
-			4: { // 20 validators
+			4: { // everything stops
+				validators: []*types.Validator{me},
+				expectedHistory: []mock.SwitchHistoryEvent{
+					0: {Operation: mock.OpStopOne},
+				},
+			},
+			5: { // 20 validators
 				validators: append(mock.NewValidators(20), me),
 				expectedHistory: []mock.SwitchHistoryEvent{
 					{


### PR DESCRIPTION
## Issue being fixed or feature implemented

If we have less than 5 validators in the validator set, we connect to all other validators.

Previously, we didn't run the connectivity logic in this case.

## What was done?

1. Improved logic in selectpeers.DIP6()
2. Updated tests

## How Has This Been Tested?

Run unit tests

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
