### PR TITLE
fix: panic on precommits does not have any +2/3 votes

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -524,6 +524,7 @@ func (vals *ValidatorSet) QuorumVotingPower() int64 {
 }
 
 // QuorumVotingThresholdPower returns the threshold power of the voting power of the quorum if all the members existed.
+// Voting is considered successful when voting power is at or above this threshold.
 func (vals *ValidatorSet) QuorumVotingThresholdPower() int64 {
 	return int64(vals.QuorumTypeThresholdCount()) * DefaultDashVotingPower
 }

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -507,13 +507,14 @@ func (voteSet *VoteSet) IsCommit() bool {
 	return voteSet.maj23 != nil
 }
 
+// HasTwoThirdsAny returns true if we are above voting threshold, regardless of the block id voted
 func (voteSet *VoteSet) HasTwoThirdsAny() bool {
 	if voteSet == nil {
 		return false
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	return voteSet.sum > voteSet.valSet.TotalVotingPower()*2/3
+	return voteSet.sum >= voteSet.valSet.QuorumVotingThresholdPower()
 }
 
 func (voteSet *VoteSet) HasAll() bool {

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -2,12 +2,16 @@ package types
 
 import (
 	"bytes"
+	"math"
+	"sort"
+	"strconv"
 	"testing"
 
+	"github.com/dashevo/dashd-go/btcjson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/bls12381"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
@@ -519,6 +523,112 @@ func TestVoteSet_MakeCommit(t *testing.T) {
 	}
 }
 
+func TestVoteSet_LLMQType_50_60(t *testing.T) {
+	testCases := []struct {
+		llmqType      btcjson.LLMQType
+		numValidators int
+		threshold     int
+	}{
+		{
+			llmqType:      btcjson.LLMQType(0), // "tendermint" algorithm
+			numValidators: 40,
+			threshold:     int(math.Floor(2.0/3.0*40)) + 1,
+		},
+		{
+			llmqType:      btcjson.LLMQType_50_60,
+			numValidators: 35,
+			threshold:     30,
+		},
+		{
+			llmqType:      btcjson.LLMQType(0),
+			numValidators: 50,
+			threshold:     34,
+		},
+		{
+			llmqType:      btcjson.LLMQType_50_60,
+			numValidators: 50,
+			threshold:     30,
+		},
+	}
+
+	for ti, tt := range testCases {
+		name := strconv.Itoa(ti)
+		t.Run(name, func(t *testing.T) {
+			height, round := int64(1), int32(0)
+			numValidators := tt.numValidators
+			llmqType := tt.llmqType
+			threshold := tt.threshold
+
+			voteSet, valSet, privValidators := randVoteSetWithLLMQType(
+				height,
+				round,
+				tmproto.PrevoteType,
+				numValidators,
+				RandStateID().WithHeight(height-1),
+				llmqType,
+				threshold,
+			)
+			assert.EqualValues(t, threshold, valSet.QuorumTypeThresholdCount())
+			assert.GreaterOrEqual(t, len(privValidators), threshold+3)
+
+			blockHash := crypto.CRandBytes(32)
+			blockPartSetHeader := PartSetHeader{uint32(123), crypto.CRandBytes(32)}
+			votedBlock := BlockID{blockHash, blockPartSetHeader}
+
+			// below threshold
+			for i := 0; i < threshold-1; i++ {
+				blockMaj, anyMaj := castVote(t, votedBlock, height, round, privValidators, int32(i), voteSet)
+				assert.False(t, blockMaj, "no block majority expected here: i=%d, threshold=%d", i, threshold)
+				assert.False(t, anyMaj, "no 'any' majority expected here: i=%d, threshold=%d", i, threshold)
+			}
+
+			// we add null vote
+			blockMaj, anyMaj := castVote(t, BlockID{}, height, round, privValidators, int32(threshold), voteSet)
+			assert.False(t, blockMaj, "no block majority expected after nil vote")
+			assert.True(t, anyMaj, "'any' majority expected  after nil vote at threshold")
+
+			// at threshold
+			blockMaj, anyMaj = castVote(t, votedBlock, height, round, privValidators, int32(threshold+1), voteSet)
+			assert.True(t, blockMaj, "block majority expected")
+			assert.True(t, anyMaj, "'any' majority expected")
+
+			// above threshold
+			blockMaj, anyMaj = castVote(t, votedBlock, height, round, privValidators, int32(threshold+2), voteSet)
+			assert.True(t, blockMaj, "block majority expected")
+			assert.True(t, anyMaj, "'any' majority expected")
+		})
+	}
+}
+
+func castVote(
+	t *testing.T,
+	blockID BlockID,
+	height int64,
+	round int32,
+	privValidators []PrivValidator,
+	validatorID int32,
+	voteSet *VoteSet,
+) (twoThirdsMajority, hasTwoThirdsAny bool) {
+	voteProto := &Vote{
+		ValidatorProTxHash: nil, // NOTE: must fill in
+		ValidatorIndex:     -1,  // NOTE: must fill in
+		Height:             height,
+		Round:              round,
+		Type:               tmproto.PrevoteType,
+		BlockID:            blockID,
+	}
+	proTxHash, err := privValidators[validatorID].GetProTxHash()
+	require.NoError(t, err)
+	vote := withValidator(voteProto, proTxHash, validatorID)
+	signed, err := signAddVote(privValidators[validatorID], vote, voteSet)
+	require.True(t, signed)
+	require.NoError(t, err)
+
+	majorityBlock, twoThirdsMajority := voteSet.TwoThirdsMajority()
+	assert.EqualValues(t, twoThirdsMajority, !majorityBlock.IsZero())
+	return twoThirdsMajority, voteSet.HasTwoThirdsAny()
+}
+
 // NOTE: privValidators are in order
 func randVoteSet(
 	height int64,
@@ -529,6 +639,37 @@ func randVoteSet(
 ) (*VoteSet, *ValidatorSet, []PrivValidator) {
 	valSet, privValidators := GenerateValidatorSet(numValidators)
 	return NewVoteSet("test_chain_id", height, round, signedMsgType, valSet, stateID), valSet, privValidators
+}
+
+func randVoteSetWithLLMQType(
+	height int64,
+	round int32,
+	signedMsgType tmproto.SignedMsgType,
+	numValidators int,
+	stateID StateID,
+	llmqType btcjson.LLMQType,
+	threshold int,
+) (*VoteSet, *ValidatorSet, []PrivValidator) {
+	var (
+		valz           = make([]*Validator, numValidators)
+		privValidators = make([]PrivValidator, numValidators)
+	)
+	privateKeys, proTxHashes, thresholdPublicKey := bls12381.CreatePrivLLMQData(numValidators, threshold)
+	quorumHash := crypto.RandQuorumHash()
+
+	for i := 0; i < numValidators; i++ {
+		privValidators[i] = NewMockPVWithParams(privateKeys[i], proTxHashes[i], quorumHash,
+			thresholdPublicKey, false, false)
+		valz[i] = NewValidatorDefaultVotingPower(privateKeys[i].PubKey(), proTxHashes[i])
+	}
+
+	sort.Sort(PrivValidatorsByProTxHash(privValidators))
+
+	valSet := NewValidatorSet(valz, thresholdPublicKey, llmqType, quorumHash, true)
+	voteSet := NewVoteSet("test_chain_id", height, round, tmproto.PrevoteType,
+		valSet, stateID)
+
+	return voteSet, valSet, privValidators
 }
 
 // Convenience: Return new vote with different validator address/index


### PR DESCRIPTION
## Issue being fixed or feature implemented

```
BUG: CONSENSUS FAILURE!!! - entering precommit wait step (12928/0), but precommits does not have any +2/3 votes
```

## What was done?

Some parts of the code were not correctly modified to support LLMQ quorums.
This PR fixes this behavior.

## How Has This Been Tested?

Added unit test, to be tested on schnapps once we have a pre-release

## Breaking Changes

None

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
