### PR TITLE
feat: use validators from init chain response or genesis to establish connection

### DIFF
--- a/dash/quorum/validator_conn_executor.go
+++ b/dash/quorum/validator_conn_executor.go
@@ -2,7 +2,6 @@ package quorum
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -23,10 +22,6 @@ const (
 	defaultTimeout = 1 * time.Second
 	// defaultEventBusCapacity determines how many events can wait in the event bus for processing. 10 looks very safe.
 	defaultEventBusCapacity = 10
-)
-
-var (
-	errValidatorsForUpdateInvalid = errors.New("no validators to establish a connection")
 )
 
 // Switch defines p2p.Switch methods that are used by this Executor.
@@ -108,7 +103,7 @@ func NewValidatorConnExecutor(
 func WithValidatorsSet(valSet *types.ValidatorSet) func(vc *ValidatorConnExecutor) error {
 	return func(vc *ValidatorConnExecutor) error {
 		if len(valSet.Validators) == 0 {
-			return errValidatorsForUpdateInvalid
+			return nil
 		}
 		err := vc.setQuorumHash(valSet.QuorumHash)
 		if err != nil {
@@ -259,8 +254,6 @@ func (vc *ValidatorConnExecutor) selectValidators() (validatorMap, error) {
 func (vc *ValidatorConnExecutor) disconnectValidator(validator types.Validator) error {
 	vc.Logger.Debug("disconnect Validator", "validator", validator)
 	address := validator.NodeAddress.String()
-
-	fmt.Printf("[DEBUG] address=%v\n", address)
 
 	err := vc.p2pSwitch.RemovePersistentPeer(address)
 	if err != nil {

--- a/dash/quorum/validator_conn_executor_test.go
+++ b/dash/quorum/validator_conn_executor_test.go
@@ -320,7 +320,8 @@ func TestEndBlock(t *testing.T) {
 	// setup ValidatorConnExecutor
 	sw := mock.NewMockSwitch()
 	nodeID := newVals.Validators[0].NodeAddress.NodeID
-	vc := NewValidatorConnExecutor(nodeID, eventBus, sw, log.TestingLogger())
+	vc, err := NewValidatorConnExecutor(nodeID, eventBus, sw)
+	require.NoError(t, err)
 	err = vc.Start()
 	require.NoError(t, err)
 	defer func() { err := vc.Stop(); require.NoError(t, err) }()
@@ -474,7 +475,8 @@ func setup(
 	sw = mock.NewMockSwitch()
 
 	nodeID := me.NodeAddress.NodeID
-	vc = NewValidatorConnExecutor(nodeID, eventBus, sw, log.TestingLogger())
+	vc, err = NewValidatorConnExecutor(nodeID, eventBus, sw)
+	require.NoError(t, err)
 	err = vc.Start()
 	require.NoError(t, err)
 

--- a/node/node.go
+++ b/node/node.go
@@ -1044,11 +1044,16 @@ func NewNode(config *cfg.Config,
 	}
 
 	// Initialize ValidatorConnExecutor
-	validatorConnExecutor := dashquorum.NewValidatorConnExecutor(
+	validatorConnExecutor, err := dashquorum.NewValidatorConnExecutor(
 		nodeInfo.ID(),
 		eventBus,
 		sw,
-		logger.With("module", "ValidatorConnExecutor"))
+		logger.With("module", "ValidatorConnExecutor"),
+		dashquorum.WithValidatorsSet(state.Validators),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	node := &Node{
 		config:        config,

--- a/node/node.go
+++ b/node/node.go
@@ -1048,7 +1048,7 @@ func NewNode(config *cfg.Config,
 		nodeInfo.ID(),
 		eventBus,
 		sw,
-		logger.With("module", "ValidatorConnExecutor"),
+		dashquorum.WithLogger(logger),
 		dashquorum.WithValidatorsSet(state.Validators),
 	)
 	if err != nil {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -582,6 +582,9 @@ func (sw *Switch) AddPersistentPeers(addrs []string) error {
 // It ignores ErrNetAddressLookup. However, if there are other errors, first encounter is
 // returned.
 func (sw *Switch) RemovePersistentPeer(addr string) error {
+	if len(sw.persistentPeersAddrs) == 0 {
+		return nil
+	}
 	sw.Logger.Info("Removing persistent peer", "addr", addr)
 	toDelete, err := NewNetAddressString(addr)
 	if err != nil {

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -20,6 +20,9 @@ runner/dashcore: runner e2e/app/compile
 runner/rotate: runner e2e/app/compile
 	./build/runner -f networks/rotate.toml
 
+runner/island: runner e2e/app/compile
+	./build/runner -f networks/island.toml
+
 # We need to build support for database backends into the app in
 # order to build a binary with a Tenderdash node in it (for built-in
 # ABCI testing).

--- a/test/e2e/networks/island.toml
+++ b/test/e2e/networks/island.toml
@@ -1,0 +1,81 @@
+initial_height = 1000
+initial_state = { initial01 = "a", initial02 = "b", initial03 = "c" }
+initial_core_chain_locked_height = 3400
+
+[chainlock_updates]
+1000 = 3450
+1004 = 3451
+1009 = 3452
+1020 = 3454
+1040 = 3500
+
+[validator_update.0]
+validator01 = 100
+validator02 = 100
+validator03 = 100
+validator04 = 100
+
+[validator_update.1010]
+validator02 = 100
+validator04 = 100
+validator06 = 100
+validator07 = 100
+
+[validator_update.1020]
+validator01 = 100
+validator03 = 100
+validator05 = 100
+validator07 = 100
+
+[validator_update.1030]
+validator01 = 100
+validator02 = 100
+validator03 = 100
+validator04 = 100
+validator05 = 100
+validator06 = 100
+validator07 = 100
+
+[node.validator01]
+snapshot_interval = 5
+perturb = ["disconnect"]
+privval_protocol = "dashcore"
+
+[node.validator02]
+database = "boltdb"
+abci_protocol = "tcp"
+privval_protocol = "dashcore"
+persist_interval = 0
+perturb = ["restart"]
+
+[node.validator03]
+database = "badgerdb"
+privval_protocol = "dashcore"
+persist_interval = 3
+retain_blocks = 3
+perturb = ["kill"]
+
+[node.validator04]
+database = "rocksdb"
+abci_protocol = "builtin"
+privval_protocol = "dashcore"
+perturb = ["pause"]
+
+[node.validator05]
+start_at = 1005
+database = "cleveldb"
+fast_sync = "v0"
+privval_protocol = "dashcore"
+perturb = ["kill", "pause", "disconnect", "restart"]
+
+[node.validator06]
+database = "rocksdb"
+fast_sync = "v0"
+privval_protocol = "dashcore"
+
+[node.validator07]
+start_at = 1005
+database = "cleveldb"
+fast_sync = "v0"
+privval_protocol = "dashcore"
+perturb = ["pause"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
if isolate every validator from each other and run e2e test, then we will see that the test fails 'cause no one validator could establish connection despite initial validator-set is provided in init-chain response. it happens due to `ValidatorConnExecutor` component doesn't establish a connection from `init-chain`.

## What was done?
<!--- Describe your changes in detail -->
Allow `ValidatorConnExecutor` using validator-set from init-chain response to establish connection with them

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using e2e test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
