### PR TITLE
test(p2p): Fix github pipeline issues in TestTransportHandshake

### DIFF
--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -569,7 +569,7 @@ func TestTransportHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(10 * time.Microsecond)
+	time.Sleep(100 * time.Microsecond)
 	var (
 		peerPV       = ed25519.GenPrivKey()
 		peerNodeInfo = testNodeInfo(PubKeyToID(peerPV.PubKey()), defaultNodeName, nil)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Inside GitHub pipeline, net.Listen() is executing quite slowly,  causing `TestTransportHandshake` test to fail with:

```
Failed to accept conn: accept tcp 127.0.0.1:44119: use of closed network connection
```

## What was done?

Increased delay between net.Listen and actual test execution

## How Has This Been Tested?

Push and see if it passed on github. Repeat a few times.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
