### PR TITLE
feat(consensus): add empty block on h-1 and h-2 apphash change

### DIFF
--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -42,6 +42,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	deliverTxsRange(cs, 0, 1)
 	ensureNewEventOnChannel(newBlockCh) // commit txs
 	ensureNewEventOnChannel(newBlockCh) // commit updated app hash
+	ensureNewEventOnChannel(newBlockCh) // commit 2nd block for updated app hash
 	ensureNoNewEventOnChannel(newBlockCh)
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dash Drive needs additional (empty) block generated after AppHash change, so that we will have 2 blocks generated for each apphash change.

## What was done?

Modified needProofBlock to check apphash from block height-1 and height-2 when determining whether or not we should force new block creation. Note this feature needs empty block creation enabled:

* create_empty_blocks: true
* create_empty_blocks_interval > 0



## How Has This Been Tested?


* Manual test by running e2e tests and observing results
* TestMempoolNoProgressUntilTxsAvailable also tests if it works


## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
