### PR TITLE
feat(consensus): add create_proof_block_range config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -919,6 +919,9 @@ type ConsensusConfig struct {
 	// EmptyBlocks mode and possible interval between empty blocks
 	CreateEmptyBlocks         bool          `mapstructure:"create_empty_blocks"`
 	CreateEmptyBlocksInterval time.Duration `mapstructure:"create_empty_blocks_interval"`
+	// CreateProofBlockRange determines how many past blocks are inspected in order to determine if we need to create
+	// additional proof block.
+	CreateProofBlockRange int64 `mapstructure:"create_proof_block_range"`
 
 	// Reactor sleep duration parameters
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer_gossip_sleep_duration"`
@@ -947,6 +950,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		DontAutoPropose:             false,
 		CreateEmptyBlocks:           true,
 		CreateEmptyBlocksInterval:   0 * time.Second,
+		CreateProofBlockRange:       2,
 		PeerGossipSleepDuration:     100 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
 		DoubleSignCheckHeight:       int64(0),
@@ -1049,6 +1053,9 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	}
 	if cfg.CreateEmptyBlocksInterval < 0 {
 		return errors.New("create_empty_blocks_interval can't be negative")
+	}
+	if cfg.CreateProofBlockRange < 1 {
+		return errors.New("create_proof_block_range must be greater or equal to 1")
 	}
 	if cfg.PeerGossipSleepDuration < 0 {
 		return errors.New("peer_gossip_sleep_duration can't be negative")

--- a/config/toml.go
+++ b/config/toml.go
@@ -442,6 +442,9 @@ skip_timeout_commit = {{ .Consensus.SkipTimeoutCommit }}
 create_empty_blocks = {{ .Consensus.CreateEmptyBlocks }}
 create_empty_blocks_interval = "{{ .Consensus.CreateEmptyBlocksInterval }}"
 
+# How many blocks are inspected in order to determine if we need to create additional proof block.
+create_proof_block_range = "{{ .Consensus.CreateProofBlockRange }}"
+
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "{{ .Consensus.PeerGossipSleepDuration }}"
 peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -33,7 +33,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 		config.Consensus.CreateEmptyBlocks = false
 		config.Consensus.CreateProofBlockRange = proofBlockRange
 
-		state, privVals := randGenesisState(1, false, 100)
+		state, privVals := randGenesisState(1, false, types.DefaultDashVotingPower)
 
 		cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 		assertMempool(cs.txNotifier).EnableTxsAvailable()

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -25,25 +25,31 @@ func assertMempool(txn txNotifier) mempl.Mempool {
 }
 
 func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
-	config := ResetConfig("consensus_mempool_txs_available_test")
-	defer os.RemoveAll(config.RootDir)
-	config.Consensus.CreateEmptyBlocks = false
+	for proofBlockRange := int64(1); proofBlockRange <= 3; proofBlockRange++ {
+		t.Logf("Checking proof block range %d", proofBlockRange)
 
-	state, privVals := randGenesisState(1, false, 100)
+		config := ResetConfig("consensus_mempool_txs_available_test")
+		defer os.RemoveAll(config.RootDir)
+		config.Consensus.CreateEmptyBlocks = false
+		config.Consensus.CreateProofBlockRange = proofBlockRange
 
-	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
-	assertMempool(cs.txNotifier).EnableTxsAvailable()
-	height, round := cs.Height, cs.Round
-	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
-	startTestRound(cs, height, round)
+		state, privVals := randGenesisState(1, false, 100)
 
-	ensureNewEventOnChannel(newBlockCh) // first block gets committed
-	ensureNoNewEventOnChannel(newBlockCh)
-	deliverTxsRange(cs, 0, 1)
-	ensureNewEventOnChannel(newBlockCh) // commit txs
-	ensureNewEventOnChannel(newBlockCh) // commit updated app hash
-	ensureNewEventOnChannel(newBlockCh) // commit 2nd block for updated app hash
-	ensureNoNewEventOnChannel(newBlockCh)
+		cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
+		assertMempool(cs.txNotifier).EnableTxsAvailable()
+		height, round := cs.Height, cs.Round
+		newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
+		startTestRound(cs, height, round)
+
+		ensureNewEventOnChannel(newBlockCh) // first block gets committed
+		ensureNoNewEventOnChannel(newBlockCh)
+		deliverTxsRange(cs, 0, 1)
+		ensureNewEventOnChannel(newBlockCh) // commit txs
+		for i := int64(0); i < proofBlockRange; i++ {
+			ensureNewEventOnChannel(newBlockCh) // commit updated app hash
+		}
+		ensureNoNewEventOnChannel(newBlockCh)
+	}
 }
 
 func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1097,7 +1097,12 @@ func (cs *State) needProofBlock(height int64) bool {
 				panic(fmt.Sprintf("needProofBlock (height=%d): last block meta for height %d not found", height, blockHeight))
 			}
 			if !bytes.Equal(cs.state.AppHash, blockMeta.Header.AppHash) {
-				cs.Logger.Debug("needProofBlock: proof block needed", "height", height, "modified_since", blockHeight)
+				cs.Logger.Debug(
+					"needProofBlock: proof block needed",
+					"height", height,
+					"modified_height", blockHeight,
+					"range", proofBlockRange,
+				)
 				return true
 			}
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1088,12 +1088,13 @@ func (cs *State) needProofBlock(height int64) bool {
 		return true
 	}
 
-	heights := []int64{height - 1, height - 2}
-	for _, blockHeight := range heights {
+	proofBlockRange := cs.config.CreateProofBlockRange
+
+	for blockHeight := height - 1; blockHeight >= height-proofBlockRange; blockHeight-- {
 		if blockHeight >= cs.state.InitialHeight {
 			blockMeta := cs.blockStore.LoadBlockMeta(blockHeight)
 			if blockMeta == nil {
-				panic(fmt.Sprintf("needProofBlock: last block meta for height %d not found", height-1))
+				panic(fmt.Sprintf("needProofBlock (height=%d): last block meta for height %d not found", height, blockHeight))
 			}
 			if !bytes.Equal(cs.state.AppHash, blockMeta.Header.AppHash) {
 				cs.Logger.Debug("needProofBlock: proof block needed", "height", height, "modified_since", blockHeight)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1102,7 +1102,6 @@ func (cs *State) needProofBlock(height int64) bool {
 		}
 	}
 
-	cs.Logger.Debug("needProofBlock: proof block not needed", "height", height)
 	return false
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Added `create_proof_block_range` configuration option to control the proof block creation algorithm.



## What was done?

1. Added `create_proof_block_range` with default value of `2`.
2. Updated `needProofBlock()` to reflect new configuration option.


## How Has This Been Tested?

With unit tests: 

`go test -test.v -test.run TestMempoolNoProgressUntilTxsAvailable ./consensus/ | grep needProofBlock `

## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
