### PR TITLE
fix(consensus): create only 1 proof block by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -950,7 +950,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		DontAutoPropose:             false,
 		CreateEmptyBlocks:           true,
 		CreateEmptyBlocksInterval:   0 * time.Second,
-		CreateProofBlockRange:       2,
+		CreateProofBlockRange:       1,
 		PeerGossipSleepDuration:     100 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
 		DoubleSignCheckHeight:       int64(0),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

In #241 , we have created a feature and configuration option that allows us to control how many additional proof blocks are created in certain circumstances. In #243 , new configuration option was added to control this behavior, but it took a default of `2` instead of `1` which was in Tenderdash 0.6. 

In this PR, we restore original behavior by setting default value of this config option to 1.


## What was done?

Set default value of `create_proof_block_range` config option to `1`.


## How Has This Been Tested?

Github pipelines (Unit tests, e2e tests)

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
