### PR TITLE
fix(consensus): race condition when logging

### DIFF
--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	cstypes "github.com/tendermint/tendermint/internal/consensus/types"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/bits"
@@ -587,4 +588,9 @@ func (ps *PeerState) StringIndented(indent string) string {
 		indent, ps.Stats,
 		indent,
 	)
+}
+
+// MarshalZerologObject formats this object for logging purposes
+func (ps *PeerState) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("peer_state", ps.String())
 }

--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
 	cstypes "github.com/tendermint/tendermint/internal/consensus/types"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/bits"

--- a/internal/consensus/types/peer_round_state.go
+++ b/internal/consensus/types/peer_round_state.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
 	"github.com/tendermint/tendermint/libs/bits"
 	"github.com/tendermint/tendermint/types"
 )

--- a/internal/consensus/types/peer_round_state.go
+++ b/internal/consensus/types/peer_round_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/tendermint/tendermint/libs/bits"
 	"github.com/tendermint/tendermint/types"
 )
@@ -92,4 +93,9 @@ func (prs PeerRoundState) StringIndented(indent string) string {
 		indent, prs.LastPrecommits, prs.LastCommitRound,
 		indent, prs.CatchupCommit, prs.CatchupCommitRound,
 		indent)
+}
+
+// MarshalZerologObject formats this object for logging purposes
+func (prs PeerRoundState) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("peer_state", prs.String())
 }

--- a/types/vote.go
+++ b/types/vote.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/dashevo/dashd-go/btcjson"
 	"github.com/rs/zerolog"
-	"github.com/tendermint/tendermint/crypto/bls12381"
 
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/bls12381"
 	"github.com/tendermint/tendermint/internal/libs/protoio"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"

--- a/types/vote.go
+++ b/types/vote.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/dashevo/dashd-go/btcjson"
+	"github.com/rs/zerolog"
 	"github.com/tendermint/tendermint/crypto/bls12381"
 
 	"github.com/tendermint/tendermint/crypto"
@@ -315,6 +316,13 @@ func (vote *Vote) ToProto() *tmproto.Vote {
 		BlockSignature:     vote.BlockSignature,
 		StateSignature:     vote.StateSignature,
 	}
+}
+
+// MarshalZerologObject formats this object for logging purposes
+func (vote *Vote) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("vote", vote.String())
+	e.Int64("height", vote.Height)
+	e.Int32("round", vote.Round)
 }
 
 // FromProto converts a proto generetad type to a handwritten type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When logging certain objects, zerolog is accessing its fields without proper locking, causing potential race conditions.

## What was done?

Implemented MarshalZerologObject method for several types that were affected:

* PeerState
* PeerRoundState
* Vote

## How Has This Been Tested?

Investigated output of unit tests

## Breaking Changes

n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
