### PR TITLE
fix(dash/quorum): tendermint stops when validator node id lookup fails

### DIFF
--- a/dash/quorum/nodeid_resolver.go
+++ b/dash/quorum/nodeid_resolver.go
@@ -49,7 +49,7 @@ func (resolver tcpNodeIDResolver) connect(host string, port uint16) (net.Conn, e
 	return connection, nil
 }
 
-// Resolve implements NodeIDResolver
+// Resolve implements NodeIDResolver
 // Resolve retrieves a node ID from remote validator and generates a correct node address.
 // Note that it is quite expensive, as it establishes secure connection to the other node
 // which is dropped afterwards.

--- a/dash/quorum/validator_conn_executor.go
+++ b/dash/quorum/validator_conn_executor.go
@@ -83,7 +83,8 @@ func NewValidatorConnExecutor(
 	}
 	vc.nodeIDResolvers = []p2p.NodeIDResolver{
 		vc.dialer,
-		NewTCPNodeIDResolver(),
+		// TODO: tcp NodeID resolver is disabled temporary.
+		//NewTCPNodeIDResolver(),
 	}
 	baseService := service.NewBaseService(log.NewNopLogger(), validatorConnExecutorName, vc)
 	vc.BaseService = *baseService

--- a/dash/quorum/validator_conn_executor.go
+++ b/dash/quorum/validator_conn_executor.go
@@ -126,11 +126,12 @@ func (vc *ValidatorConnExecutor) OnStart() error {
 	if err := vc.subscribe(); err != nil {
 		return err
 	}
+	// TODO the operation is temp disabled if it's enabled then it leads to failure if even one node is unavailable
 	// establish connection with validators retrieves from genesis or init-chain
-	err := vc.updateConnections()
-	if err != nil {
-		return err
-	}
+	//err := vc.updateConnections()
+	//if err != nil {
+	//	return err
+	//}
 	go func() {
 		var err error
 		for err == nil {

--- a/dash/quorum/validator_conn_executor.go
+++ b/dash/quorum/validator_conn_executor.go
@@ -83,8 +83,7 @@ func NewValidatorConnExecutor(
 	}
 	vc.nodeIDResolvers = []p2p.NodeIDResolver{
 		vc.dialer,
-		// TODO: tcp NodeID resolver is disabled temporary.
-		//NewTCPNodeIDResolver(),
+		NewTCPNodeIDResolver(),
 	}
 	baseService := service.NewBaseService(log.NewNopLogger(), validatorConnExecutorName, vc)
 	vc.BaseService = *baseService
@@ -126,12 +125,10 @@ func (vc *ValidatorConnExecutor) OnStart() error {
 	if err := vc.subscribe(); err != nil {
 		return err
 	}
-	// TODO the operation is temp disabled if it's enabled then it leads to failure if even one node is unavailable
-	// establish connection with validators retrieves from genesis or init-chain
-	//err := vc.updateConnections()
-	//if err != nil {
-	//	return err
-	//}
+	err := vc.updateConnections()
+	if err != nil {
+		return err
+	}
 	go func() {
 		var err error
 		for err == nil {
@@ -244,20 +241,26 @@ func (vc *ValidatorConnExecutor) resolveNodeID(va *types.ValidatorAddress) error
 	if va.NodeID != "" {
 		return nil
 	}
+	var allErrors string
 	for _, resolver := range vc.nodeIDResolvers {
 		address, err := resolver.Resolve(*va)
 		if err == nil && address.NodeID != "" {
 			va.NodeID = address.NodeID
-			return nil
+			return nil // success
 		}
+
+		method := reflect.TypeOf(resolver).String()
 		vc.Logger.Debug(
 			"warning: validator node id lookup method failed",
 			"url", va.String(),
-			"method", reflect.TypeOf(resolver).String(),
+			"method", method,
 			"error", err,
 		)
+
+		allErrors += method + " error: " + err.Error() + "; "
 	}
-	return types.ErrNoNodeID
+
+	return types.ErrNoNodeID(errors.New(allErrors))
 }
 
 // selectValidators selects `count` validators from current ValidatorSet.
@@ -275,16 +278,26 @@ func (vc *ValidatorConnExecutor) selectValidators() (validatorMap, error) {
 	if err != nil {
 		return validatorMap{}, err
 	}
+
 	// fetch node IDs
-	for _, validator := range selectedValidators {
+	selectedValidators = vc.ensureValidatorsHaveNodeIDs(selectedValidators)
+	return newValidatorMap(selectedValidators), nil
+}
+
+// ensureValidatorsHaveNodeIDs will determine Node IDs for `validators`.
+// Note that it modifies members of `validators` slice.
+// Returns subset of `validators` slice containing only validators with valid node
+func (vc *ValidatorConnExecutor) ensureValidatorsHaveNodeIDs(validators []*types.Validator) (results []*types.Validator) {
+	results = make([]*types.Validator, 0, len(validators))
+	for _, validator := range validators {
 		err := vc.resolveNodeID(&validator.NodeAddress)
 		if err != nil {
-			vc.Logger.Debug("cannot determine node id for validator", "url", validator.String(), "error", err)
-			// no return, as it's not critical
+			vc.Logger.Error("cannot determine node id for validator, skipping", "url", validator.String(), "error", err)
+			continue
 		}
+		results = append(results, validator)
 	}
-
-	return newValidatorMap(selectedValidators), nil
+	return results
 }
 
 func (vc *ValidatorConnExecutor) disconnectValidator(validator types.Validator) error {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lib/pq v1.10.4
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/minio/highwayhash v1.0.2

--- a/internal/p2p/dash_dialer.go
+++ b/internal/p2p/dash_dialer.go
@@ -118,5 +118,5 @@ func (cm *routerDashDialer) lookupIPPort(ctx context.Context, ip net.IP, port ui
 		}
 	}
 
-	return NodeAddress{}, errPeerNotFound(fmt.Errorf("peer %s:%dd not found in the address book", ip, port))
+	return NodeAddress{}, errPeerNotFound(fmt.Errorf("peer %s:%d not found in the address book", ip, port))
 }

--- a/test/e2e/networks/rotate.toml
+++ b/test/e2e/networks/rotate.toml
@@ -6,6 +6,7 @@ initial_state = { initial01 = "a", initial02 = "b", initial03 = "c" }
 initial_core_chain_locked_height = 3400
 init_app_core_chain_locked_height = 2308 # should override initial_core_chain_locked_height
 queue_type = "priority"
+log_level = "debug"
 
 [chainlock_updates]
 1000 = 3450

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gogo/protobuf/proto"
+
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/bls12381"
@@ -298,7 +299,6 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.P2P.ExternalAddress = fmt.Sprintf("tcp://%v", node.AddressP2P(false))
 	cfg.P2P.AddrBookStrict = false
 	cfg.Consensus.AppHashSize = crypto.DefaultAppHashSize
-	cfg.BaseConfig.LogLevel = "info"
 	cfg.P2P.UseLegacy = node.UseLegacyP2P
 	cfg.P2P.QueueType = node.QueueType
 	cfg.DBBackend = node.Database

--- a/types/validator_address.go
+++ b/types/validator_address.go
@@ -26,13 +26,11 @@ type ValidatorAddress struct {
 	Port     uint16
 }
 
-type (
+var (
 	// ErrNoHostname is returned when no hostname is set for the validator address
-	ErrNoHostname error
+	ErrNoHostname = errors.New("no hostname")
 	// ErrNoPort is returned when no valid port is set for the validator address
-	ErrNoPort error
-	// ErrNoNodeID is returned when node ID is not set for the node ID
-	ErrNoNodeID error
+	ErrNoPort = errors.New("no port")
 )
 
 // ParseValidatorAddress parses provided address, which should be in `proto://nodeID@host:port` form.
@@ -95,10 +93,10 @@ func parseValidatorAddressString(urlString string) (ValidatorAddress, error) {
 func (va ValidatorAddress) Validate() error {
 
 	if va.Hostname == "" {
-		return ErrNoHostname(errors.New("hostname not set"))
+		return ErrNoHostname
 	}
 	if va.Port <= 0 {
-		return ErrNoPort(errors.New("port not defined"))
+		return ErrNoPort
 	}
 	if len(va.NodeID) > 0 {
 		if err := va.NodeID.Validate(); err != nil {

--- a/types/validator_address.go
+++ b/types/validator_address.go
@@ -26,13 +26,13 @@ type ValidatorAddress struct {
 	Port     uint16
 }
 
-var (
+type (
 	// ErrNoHostname is returned when no hostname is set for the validator address
-	ErrNoHostname = errors.New("no hostname")
+	ErrNoHostname error
 	// ErrNoPort is returned when no valid port is set for the validator address
-	ErrNoPort = errors.New("no port")
+	ErrNoPort error
 	// ErrNoNodeID is returned when node ID is not set for the node ID
-	ErrNoNodeID = errors.New("no node ID")
+	ErrNoNodeID error
 )
 
 // ParseValidatorAddress parses provided address, which should be in `proto://nodeID@host:port` form.
@@ -95,10 +95,10 @@ func parseValidatorAddressString(urlString string) (ValidatorAddress, error) {
 func (va ValidatorAddress) Validate() error {
 
 	if va.Hostname == "" {
-		return ErrNoHostname
+		return ErrNoHostname(errors.New("hostname not set"))
 	}
 	if va.Port <= 0 {
-		return ErrNoPort
+		return ErrNoPort(errors.New("port not defined"))
 	}
 	if len(va.NodeID) > 0 {
 		if err := va.NodeID.Validate(); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tcp NodeID resolver is stopped running ValidatorConnExecutor, if even one node is unavailable

## What was done?
<!--- Describe your changes in detail -->
Node ID resolve failures are not critical. We just skill nodes where we cannot determine node ID.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using e2e test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
