### PR TITLE
fix(consensus): Decrease memory used by debug logs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dashevo/dashd-go/btcjson"
+
 	"github.com/tendermint/tendermint/crypto"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"

--- a/internal/blocksync/v0/reactor.go
+++ b/internal/blocksync/v0/reactor.go
@@ -292,7 +292,7 @@ func (r *Reactor) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (err 
 		}
 	}()
 
-	r.Logger.Debug("received message", "msg", envelope.Message, "peer", envelope.From)
+	// r.Logger.Debug("received message", "msg", envelope.Message, "peer", envelope.From)
 
 	switch chID {
 	case BlockSyncChannel:

--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -419,7 +419,6 @@ func (ps *PeerState) SetHasCommit(commit *types.Commit) {
 }
 
 func (ps *PeerState) setHasCommit(height int64, round int32) {
-	// Don't create a new logger here with logger.With(), as this adds significant memory overhead.
 	ps.logger.Debug(
 		"setHasCommit",
 		"height", height,

--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -384,16 +384,13 @@ func (ps *PeerState) SetHasVote(vote *types.Vote) {
 
 func (ps *PeerState) setHasVote(height int64, round int32, voteType tmproto.SignedMsgType, index int32) {
 
-	logger := ps.logger.With(
+	ps.logger.Debug(
+		"peerState setHasVote",
 		"peer_id", ps.peerID,
 		"height", height,
 		"round", round,
 		"peer_height", ps.PRS.Height,
 		"peer_round", ps.PRS.Round,
-	)
-
-	logger.Debug(
-		"peerState setHasVote",
 		"type", voteType,
 		"index", index,
 		"peerVotes", ps.Stats.Votes,
@@ -422,6 +419,7 @@ func (ps *PeerState) SetHasCommit(commit *types.Commit) {
 }
 
 func (ps *PeerState) setHasCommit(height int64, round int32) {
+	// Don't create a new logger here with logger.With(), as this adds significant memory overhead.
 	ps.logger.Debug(
 		"setHasCommit",
 		"height", height,

--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -411,15 +411,6 @@ func (ps *PeerState) SetHasCommit(commit *types.Commit) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 
-	ps.logger.
-		With(
-			"height", commit.Height,
-			"round", commit.Round,
-			"peer_height", ps.PRS.Height,
-			"peer_round", ps.PRS.Round,
-		).
-		Debug("setHasCommit")
-
 	ps.setHasCommit(commit.Height, commit.Round)
 
 	if ps.PRS.Height < commit.Height || (ps.PRS.Height == commit.Height && ps.PRS.Round < commit.Round) {
@@ -431,13 +422,13 @@ func (ps *PeerState) SetHasCommit(commit *types.Commit) {
 }
 
 func (ps *PeerState) setHasCommit(height int64, round int32) {
-	logger := ps.logger.With(
+	ps.logger.Debug(
+		"setHasCommit",
 		"height", height,
 		"round", round,
 		"peer_height", ps.PRS.Height,
 		"peer_round", ps.PRS.Round,
 	)
-	logger.Debug("setHasCommit")
 
 	if ps.PRS.Height < height || (ps.PRS.Height == height && ps.PRS.Round <= round) {
 		ps.PRS.Height = height

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -1284,7 +1284,7 @@ func (r *Reactor) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (err 
 		return err
 	}
 
-	r.Logger.Debug("received message", "ch_id", chID, "msg", msgI, "peer", envelope.From)
+	// r.Logger.Debug("received message", "ch_id", chID, "msg", msgI, "peer", envelope.From)
 
 	switch chID {
 	case StateChannel:

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2392,6 +2392,14 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 
 		added, err = cs.LastPrecommits.AddVote(vote)
 		if !added {
+			cs.Logger.Debug(
+				"vote not added",
+				"height", vote.Height,
+				"vote_type", vote.Type,
+				"val_index", vote.ValidatorIndex,
+				"cs_height", cs.Height,
+				"error", err,
+			)
 			return
 		}
 

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -174,7 +174,7 @@ func (r *Reactor) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (err 
 		}
 	}()
 
-	r.Logger.Debug("received message", "msg", envelope.Message, "peer", envelope.From)
+	// r.Logger.Debug("received message", "msg", envelope.Message, "peer", envelope.From)
 
 	switch chID {
 	case EvidenceChannel:

--- a/internal/mempool/v0/reactor.go
+++ b/internal/mempool/v0/reactor.go
@@ -197,7 +197,7 @@ func (r *Reactor) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (err 
 		}
 	}()
 
-	r.Logger.Debug("received message", "peer", envelope.From)
+	// r.Logger.Debug("received message", "peer", envelope.From)
 
 	switch chID {
 	case mempool.MempoolChannel:

--- a/internal/mempool/v1/reactor.go
+++ b/internal/mempool/v1/reactor.go
@@ -205,7 +205,7 @@ func (r *Reactor) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (err 
 		}
 	}()
 
-	r.Logger.Debug("received message", "peer", envelope.From)
+	// r.Logger.Debug("received message", "peer", envelope.From)
 
 	switch chID {
 	case mempool.MempoolChannel:

--- a/internal/p2p/pex/pex_reactor.go
+++ b/internal/p2p/pex/pex_reactor.go
@@ -255,7 +255,7 @@ func (r *Reactor) Receive(chID byte, src Peer, msgBytes []byte) {
 		r.Switch.StopPeerForError(src, err)
 		return
 	}
-	r.Logger.Debug("Received message", "src", src, "chId", chID, "msg", msg)
+	// r.Logger.Debug("Received message", "src", src, "chId", chID, "msg", msg)
 
 	switch msg := msg.(type) {
 	case *tmp2p.PexRequest:

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -942,7 +942,7 @@ func (r *Router) receivePeer(peerID types.NodeID, conn Connection) error {
 				"peer_id", string(peerID),
 				"message_type", r.metrics.ValueToMetricLabel(msg)).Add(float64(proto.Size(msg)))
 			r.metrics.RouterChannelQueueSend.Observe(time.Since(start).Seconds())
-			r.logger.Debug("received message", "peer", peerID, "msg", msg)
+			// r.logger.Debug("received message", "peer", peerID, "msg", msg)
 
 		case <-queue.closed():
 			r.logger.Debug("channel closed, dropping message", "peer", peerID, "channel", chID)
@@ -977,7 +977,7 @@ func (r *Router) sendPeer(peerID types.NodeID, conn Connection, peerQueue queue)
 				return err
 			}
 
-			r.logger.Debug("sent message", "peer", envelope.To, "message", envelope.Message)
+			// r.logger.Debug("sent message", "peer", envelope.To, "message", envelope.Message)
 
 		case <-peerQueue.closed():
 			return nil

--- a/internal/p2p/transport_memory.go
+++ b/internal/p2p/transport_memory.go
@@ -308,7 +308,7 @@ func (c *MemoryConnection) ReceiveMessage() (ChannelID, []byte, error) {
 
 	select {
 	case msg := <-c.receiveCh:
-		c.logger.Debug("received message", "chID", msg.channelID, "msg", msg.message)
+		// c.logger.Debug("received message", "chID", msg.channelID, "msg", msg.message)
 		return msg.channelID, msg.message, nil
 	case <-c.closer.Done():
 		return 0, nil, io.EOF
@@ -327,7 +327,7 @@ func (c *MemoryConnection) SendMessage(chID ChannelID, msg []byte) (bool, error)
 
 	select {
 	case c.sendCh <- memoryMessage{channelID: chID, message: msg}:
-		c.logger.Debug("sent message", "chID", chID, "msg", msg)
+		// c.logger.Debug("sent message", "chID", chID, "msg", msg)
 		return true, nil
 	case <-c.closer.Done():
 		return false, io.EOF
@@ -346,7 +346,7 @@ func (c *MemoryConnection) TrySendMessage(chID ChannelID, msg []byte) (bool, err
 
 	select {
 	case c.sendCh <- memoryMessage{channelID: chID, message: msg}:
-		c.logger.Debug("sent message", "chID", chID, "msg", msg)
+		// c.logger.Debug("sent message", "chID", chID, "msg", msg)
 		return true, nil
 	case <-c.closer.Done():
 		return false, io.EOF

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"runtime/debug"
 	"sort"
 	"time"
@@ -812,7 +811,7 @@ func (r *Reactor) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (err 
 		}
 	}()
 
-	r.Logger.Debug("received message", "msg", reflect.TypeOf(envelope.Message), "peer", envelope.From)
+	// r.Logger.Debug("received message", "msg", reflect.TypeOf(envelope.Message), "peer", envelope.From)
 
 	switch chID {
 	case SnapshotChannel:

--- a/libs/log/default.go
+++ b/libs/log/default.go
@@ -103,9 +103,15 @@ func getLogFields(keyVals ...interface{}) map[string]interface{} {
 		return nil
 	}
 
+	var fieldName string
 	fields := make(map[string]interface{}, len(keyVals))
 	for i := 0; i < len(keyVals); i += 2 {
-		fields[fmt.Sprint(keyVals[i])] = keyVals[i+1]
+		if val, ok := keyVals[i].(string); ok {
+			fieldName = val
+		} else {
+			fieldName = fmt.Sprint(keyVals[i])
+		}
+		fields[fieldName] = keyVals[i+1]
 	}
 
 	return fields

--- a/types/block.go
+++ b/types/block.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/dashevo/dashd-go/btcjson"
+	"github.com/rs/zerolog"
 
 	"github.com/gogo/protobuf/proto"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -839,6 +841,16 @@ func (commit *Commit) StringIndented(indent string) string {
 		indent, base64.StdEncoding.EncodeToString(commit.ThresholdBlockSignature),
 		indent, base64.StdEncoding.EncodeToString(commit.ThresholdStateSignature),
 		indent, commit.hash)
+}
+
+// MarshalZerologObject formats this object for logging purposes
+func (commit *Commit) MarshalZerologObject(e *zerolog.Event) {
+	e.Int64("height", commit.Height)
+	e.Int32("round", commit.Round)
+	e.Str("BlockID.Hash", commit.BlockID.Hash.String())
+	e.Str("StateID", commit.StateID.String())
+	e.Str("BlockSignature", hex.EncodeToString(commit.ThresholdBlockSignature))
+	e.Str("StateSignature", hex.EncodeToString(commit.ThresholdStateSignature))
 }
 
 // ToProto converts Commit to protobuf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented


Debug logs use huge amount of memory, causing some consensus tests to fail due to performance issues.
This PR fixes the biggest issues, and also significantly reduces amount of generated logs.


## What was done?

1. Decrease usage of `logger.With()` that take much memory and create new Log object
2. Added zerolog marshaller to Commit message, to allow more selective logging
3. Commented out `received message` and `sent message` debug logs to significantly decrease amount of generated logs
4. Removed redundant logs
5. Improved performance of key-value processing in logs

## How Has This Been Tested?

Ran consensus test that was failing: 

```
go test ./internal/consensus/ -test.timeout 60s -test.run TestReactorValidatorSetChanges  -memprofile memprofile.out -cpuprofile cpuprofile.out -count 1 -test.v 
```

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
