### PR TITLE
refactor(consensus): replace message process handlers on a common one

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -594,6 +594,27 @@ func (cs *State) SetProposalAndBlock(
 	return nil
 }
 
+// InitialHeight returns an initial height
+func (cs *State) InitialHeight() int64 {
+	cs.mtx.RLock()
+	defer cs.mtx.RUnlock()
+	return cs.state.InitialHeight
+}
+
+// CurrentHeight returns a current/last height
+func (cs *State) CurrentHeight() int64 {
+	cs.mtx.RLock()
+	defer cs.mtx.RUnlock()
+	return cs.Height
+}
+
+// HeightVoteSet returns a height-vote-set manager
+func (cs *State) HeightVoteSet() *cstypes.HeightVoteSet {
+	cs.mtx.RLock()
+	defer cs.mtx.RUnlock()
+	return cs.Votes
+}
+
 //------------------------------------------------------------
 // internal functions for managing the state
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed that there are several functions with identical bodies. This PR replaced those functions on one that covers all required logic.

## What was done?
<!--- Describe your changes in detail -->
Following functions
* `processStateCh`
* `processDataCh`
* `processVoteCh`
* `processVoteSetBitsCh`
were replaced with this function `processMsgCh`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
