### PR TITLE
test(mempool): fix test of KeepInvalidTxsInCache

### DIFF
--- a/internal/mempool/v0/clist_mempool.go
+++ b/internal/mempool/v0/clist_mempool.go
@@ -251,7 +251,7 @@ func (mem *CListMempool) CheckTx(
 			}
 		}
 
-		mem.logger.Debug("tx exists already in cache", "tx_hash", tx.Hash())
+		mem.logger.Debug("tx exists already in cache", "tx", tx.Hash())
 		return nil
 	}
 

--- a/internal/mempool/v1/mempool.go
+++ b/internal/mempool/v1/mempool.go
@@ -271,7 +271,7 @@ func (txmp *TxMempool) CheckTx(
 			return types.ErrTxInCache
 		}
 
-		txmp.logger.Debug("tx exists already in cache", "tx_hash", tx.Hash())
+		txmp.logger.Debug("tx exists already in cache", "tx", tx.Hash())
 		return nil
 	}
 

--- a/types/tx.go
+++ b/types/tx.go
@@ -21,7 +21,7 @@ type Tx []byte
 func (tx Tx) Key() TxKey { return sha256.Sum256(tx) }
 
 // Hash computes the TMHASH hash of the wire encoded transaction.
-func (tx Tx) Hash() []byte { return tmhash.Sum(tx) }
+func (tx Tx) Hash() tmbytes.HexBytes { return tmhash.Sum(tx) }
 
 // String returns the hex-encoded transaction as a string.
 func (tx Tx) String() string { return fmt.Sprintf("Tx{%X}", []byte(tx)) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Test TestMempool_KeepInvalidTxsInCache didn't correctly check if KeepInvalidTxsInCache actually works.

## What was done?

Updated the test to ensure it really verifies if setting KeepInvalidTxsInCache to true/false works  correctly.


## How Has This Been Tested?

Run it.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
