### PR TITLE
build: fix golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           sudo cp -vr ~/bls-cache/include/* /usr/local/include/
           sudo cp -vr ~/bls-cache/libchiabls.a /usr/local/lib/
-      - uses: golangci/golangci-lint-action@v3.1.0
+      - uses: golangci/golangci-lint-action@v2.5.2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.42.1


### PR DESCRIPTION
## Issue being fixed or feature implemented

After update, golangci-lint fails due to dependencies on cobra and viper. We don't support recent cobra/viper yet.

## What was done?

Revert golangci-lint-action to 2.5.2


## How Has This Been Tested?

Push and see if linter passes

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
