### PR TITLE
refactor(config)!: replace is-masternode config with mode=validator

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -230,9 +230,6 @@ type BaseConfig struct { //nolint: maligned
 	// Path to the JSON file containing the initial validator set and other meta data
 	Genesis string `mapstructure:"genesis-file"`
 
-	// Set to whether the node is a masternode or not
-	IsMasternode bool `mapstructure:"is-masternode"`
-
 	// RPC port for Tendermint to query for
 	// an external PrivValidator process
 	PrivValidatorCoreRPCHost string `mapstructure:"priv-validator-core-rpc-host"`
@@ -260,7 +257,6 @@ type BaseConfig struct { //nolint: maligned
 func DefaultBaseConfig() BaseConfig {
 	return BaseConfig{
 		Genesis:                      defaultGenesisJSONPath,
-		IsMasternode:                 true,
 		PrivValidatorCoreRPCHost:     "",
 		PrivValidatorCoreRPCUsername: "dashrpc",
 		PrivValidatorCoreRPCPassword: "rpcpassword",
@@ -281,7 +277,6 @@ func DefaultBaseConfig() BaseConfig {
 func SingleNodeBaseConfig() BaseConfig {
 	return BaseConfig{
 		Genesis:                      defaultGenesisJSONPath,
-		IsMasternode:                 true,
 		PrivValidatorCoreRPCHost:     "",
 		PrivValidatorCoreRPCUsername: "",
 		PrivValidatorCoreRPCPassword: "",

--- a/config/toml.go
+++ b/config/toml.go
@@ -154,9 +154,6 @@ filter-peers = {{ .BaseConfig.FilterPeers }}
 #######################################################
 [priv-validator]
 
-# Set to whether we are a masternode or not
-is_masternode = {{ .BaseConfig.IsMasternode }}
-
 # Path to the JSON file containing the private key to use as a validator in the consensus protocol
 key-file = "{{ js .PrivValidator.Key }}"
 

--- a/node/node.go
+++ b/node/node.go
@@ -199,7 +199,7 @@ func makeNode(cfg *config.Config,
 			dashCoreRPCClient = rpcClient
 		}
 
-		if cfg.IsMasternode {
+		if cfg.Mode == config.ModeValidator {
 			// If a local port is provided for Dash Core rpc into the service to sign.
 			privValidator, err = createAndStartPrivValidatorRPCClient(
 				cfg.Consensus.QuorumType,
@@ -235,7 +235,7 @@ func makeNode(cfg *config.Config,
 				return nil, fmt.Errorf("error with private validator socket client: %w", err)
 			}
 		}
-		if cfg.IsMasternode {
+		if cfg.Mode == config.ModeValidator {
 			proTxHash, err = privValidator.GetProTxHash(context.TODO())
 			if err != nil {
 				return nil, fmt.Errorf("can't get proTxHash using dash core signing: %w", err)


### PR DESCRIPTION
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With introduction of `mode` config option, we don't need `is-masternode`
config option anymore.
Masternodes should have `mode=validator` set in their configs.

## What was done?


* removed is-masternode config option

## How Has This Been Tested?

e2e tests, to be tested on devnet

## Breaking Changes

Removed `is-masternode` config option from configuration file.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
