### PR TITLE
refactor: add MustPubKeyToProto helper function

### DIFF
--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -47,6 +47,15 @@ func PubKeyToProto(k crypto.PubKey) (cryptoproto.PublicKey, error) {
 	return kp, nil
 }
 
+// MustPubKeyToProto returns protobuf encoded public-key otherwise panics error
+func MustPubKeyToProto(k crypto.PubKey) cryptoproto.PublicKey {
+	pubKey, err := PubKeyToProto(k)
+	if err != nil {
+		panic(err)
+	}
+	return pubKey
+}
+
 // PubKeyFromProto takes a protobuf Pubkey and transforms it to a crypto.Pubkey
 func PubKeyFromProto(k cryptoproto.PublicKey) (crypto.PubKey, error) {
 	if k.Sum == nil {

--- a/internal/p2p/conn/evil_secret_connection_test.go
+++ b/internal/p2p/conn/evil_secret_connection_test.go
@@ -113,10 +113,7 @@ func (c *evilConn) Read(data []byte) (n int, err error) {
 	case 1:
 		signature := c.signChallenge()
 		if !c.badAuthSignature {
-			pkpb, err := encoding.PubKeyToProto(c.privKey.PubKey())
-			if err != nil {
-				panic(err)
-			}
+			pkpb := encoding.MustPubKeyToProto(c.privKey.PubKey())
 			bz, err := protoio.MarshalDelimited(&tmp2p.AuthSigMessage{PubKey: pkpb, Sig: signature})
 			if err != nil {
 				panic(err)

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -305,10 +305,7 @@ func (app *Application) validatorSetUpdates(height uint64) (*abci.ValidatorSetUp
 		return nil, fmt.Errorf("invalid base64 pubkey value %q: %w", thresholdPublicKeyUpdateString, err)
 	}
 	thresholdPublicKeyUpdate := bls12381.PubKey(thresholdPublicKeyUpdateBytes)
-	abciThresholdPublicKeyUpdate, err := encoding.PubKeyToProto(thresholdPublicKeyUpdate)
-	if err != nil {
-		panic(err)
-	}
+	abciThresholdPublicKeyUpdate := encoding.MustPubKeyToProto(thresholdPublicKeyUpdate)
 
 	quorumHashUpdateString := app.cfg.QuorumHashUpdate[fmt.Sprintf("%v", height)]
 	if len(quorumHashUpdateString) == 0 {

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -53,10 +53,7 @@ func (tm2pb) ValidatorUpdate(val *Validator) abci.ValidatorUpdate {
 		NodeAddress: val.NodeAddress.String(),
 	}
 	if val.PubKey != nil {
-		pk, err := cryptoenc.PubKeyToProto(val.PubKey)
-		if err != nil {
-			panic(err)
-		}
+		pk := cryptoenc.MustPubKeyToProto(val.PubKey)
 		valUpdate.PubKey = &pk
 	}
 	return valUpdate
@@ -68,10 +65,7 @@ func (tm2pb) ValidatorUpdates(vals *ValidatorSet) abci.ValidatorSetUpdate {
 	for i, val := range vals.Validators {
 		validators[i] = TM2PB.ValidatorUpdate(val)
 	}
-	abciThresholdPublicKey, err := cryptoenc.PubKeyToProto(vals.ThresholdPublicKey)
-	if err != nil {
-		panic(err)
-	}
+	abciThresholdPublicKey := cryptoenc.MustPubKeyToProto(vals.ThresholdPublicKey)
 	return abci.ValidatorSetUpdate{
 		ValidatorUpdates:   validators,
 		ThresholdPublicKey: abciThresholdPublicKey,
@@ -88,10 +82,7 @@ func (tm2pb) NewValidatorUpdate(
 ) abci.ValidatorUpdate {
 	var pubkeyABCI *crypto2.PublicKey
 	if pubkey != nil {
-		pubkeyProto, err := cryptoenc.PubKeyToProto(pubkey)
-		if err != nil {
-			panic(err)
-		}
+		pubkeyProto := cryptoenc.MustPubKeyToProto(pubkey)
 		pubkeyABCI = &pubkeyProto
 	} else {
 		pubkeyABCI = nil

--- a/types/validator.go
+++ b/types/validator.go
@@ -197,10 +197,7 @@ func ValidatorListString(vals []*Validator) string {
 // as its redundant with the pubkey. This also excludes ProposerPriority
 // which changes every round.
 func (v *Validator) Bytes() []byte {
-	pk, err := ce.PubKeyToProto(v.PubKey)
-	if err != nil {
-		panic(err)
-	}
+	pk := ce.MustPubKeyToProto(v.PubKey)
 
 	pbv := tmproto.SimpleValidator{
 		PubKey:      &pk,

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -1016,10 +1016,7 @@ func (vals *ValidatorSet) ABCIEquivalentValidatorUpdates() *abci.ValidatorSetUpd
 			vals.Validators[i].ProTxHash, vals.Validators[i].NodeAddress.String())
 		valUpdates = append(valUpdates, valUpdate)
 	}
-	abciThresholdPublicKey, err := cryptoenc.PubKeyToProto(vals.ThresholdPublicKey)
-	if err != nil {
-		panic(err)
-	}
+	abciThresholdPublicKey := cryptoenc.MustPubKeyToProto(vals.ThresholdPublicKey)
 	return &abci.ValidatorSetUpdate{
 		ValidatorUpdates:   valUpdates,
 		ThresholdPublicKey: abciThresholdPublicKey,
@@ -1287,10 +1284,7 @@ func ValidatorUpdatesRegenerateOnProTxHashes(proTxHashes []crypto.ProTxHash) abc
 		)
 		valUpdates = append(valUpdates, valUpdate)
 	}
-	abciThresholdPublicKey, err := cryptoenc.PubKeyToProto(thresholdPublicKey)
-	if err != nil {
-		panic(err)
-	}
+	abciThresholdPublicKey := cryptoenc.MustPubKeyToProto(thresholdPublicKey)
 	return abci.ValidatorSetUpdate{
 		ValidatorUpdates:   valUpdates,
 		ThresholdPublicKey: abciThresholdPublicKey,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add `MustPubKeyToProto` helper function to encode public-key into protobuf or panic if an error occurs.
It is a utility function to simplify writing a code without checking error and panic in use-cases

## What was done?
<!--- Describe your changes in detail -->
* added implementation `MustPubKeyToProto`
* replaced using `PubKeyToProto` with panic on `MustPubKeyToProto`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
