### PR TITLE
fix(consensus): network stuck due to outdated proposal block

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1181,12 +1181,31 @@ func (cs *State) isProposer(proTxHash crypto.ProTxHash) bool {
 	return bytes.Equal(cs.Validators.GetProposer().ProTxHash.Bytes(), proTxHash.Bytes())
 }
 
+// checkValidBlock returns true if cs.ValidBlock is set and still valid (not expired)
+func (cs *State) checkValidBlock() bool {
+	if cs.ValidBlock == nil {
+		return false
+	}
+	if err := cs.blockExec.ValidateBlockTime(cs.config.ProposedBlockTimeWindow, cs.state, cs.ValidBlock); err != nil {
+		cs.Logger.Debug(
+			"proposal block is outdated",
+			"height", cs.Height,
+			"round", cs.Round,
+			"error", err,
+			"block", cs.ValidBlock)
+
+		return false
+	}
+
+	return true
+}
+
 func (cs *State) defaultDecideProposal(height int64, round int32) {
 	var block *types.Block
 	var blockParts *types.PartSet
 
 	// Decide on block
-	if cs.ValidBlock != nil {
+	if cs.checkValidBlock() {
 		// If there is valid block, choose that.
 		block, blockParts = cs.ValidBlock, cs.ValidBlockParts
 	} else {
@@ -1204,7 +1223,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	}
 
 	// Make proposal
-	propBlockID := types.BlockID{Hash: block.Hash(), PartSetHeader: blockParts.Header()}
+	propBlockID := block.BlockID(blockParts.Header())
 	proposedChainLockHeight := cs.state.LastCoreChainLockedBlockHeight
 	if cs.blockExec.NextCoreChainLock != nil && cs.blockExec.NextCoreChainLock.CoreBlockHeight > proposedChainLockHeight {
 		proposedChainLockHeight = cs.blockExec.NextCoreChainLock.CoreBlockHeight

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -794,7 +794,7 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			}
 		}
 
-		rs := cs.RoundState
+		rs := cs.GetRoundState()
 		var mi msgInfo
 
 		select {
@@ -837,7 +837,7 @@ func (cs *State) receiveRoutine(maxSteps int) {
 
 			// if the timeout is relevant to the rs
 			// go to the next step
-			cs.handleTimeout(ti, rs)
+			cs.handleTimeout(ti, *rs)
 
 		case <-cs.Quit():
 			onExit(cs)

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -291,9 +291,7 @@ func TestStateProposalTime(t *testing.T) {
 			cs.ValidBlockParts = propBlockParts
 
 			// sleep if needed
-			if tc.sleep > 0 {
-				time.Sleep(tc.sleep)
-			}
+			time.Sleep(tc.sleep)
 
 			// Wait for complete proposal.
 			cs.enterPropose(height, round)

--- a/crypto/xchacha20poly1305/xchachapoly_test.go
+++ b/crypto/xchacha20poly1305/xchachapoly_test.go
@@ -25,19 +25,19 @@ func TestRandom(t *testing.T) {
 		plaintext := make([]byte, pl)
 		_, err := cr.Read(key[:])
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %s", err.Error())
 		}
 		_, err = cr.Read(nonce[:])
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %s", err.Error())
 		}
 		_, err = cr.Read(ad)
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %s", err.Error())
 		}
 		_, err = cr.Read(plaintext)
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %s", err.Error())
 		}
 
 		aead, err := New(key[:])

--- a/crypto/xchacha20poly1305/xchachapoly_test.go
+++ b/crypto/xchacha20poly1305/xchachapoly_test.go
@@ -25,19 +25,19 @@ func TestRandom(t *testing.T) {
 		plaintext := make([]byte, pl)
 		_, err := cr.Read(key[:])
 		if err != nil {
-			t.Errorf("error on read: %s", err.Error())
+			t.Error("error on read: " + err.Error())
 		}
 		_, err = cr.Read(nonce[:])
 		if err != nil {
-			t.Errorf("error on read: %s", err.Error())
+			t.Error("error on read: " + err.Error())
 		}
 		_, err = cr.Read(ad)
 		if err != nil {
-			t.Errorf("error on read: %s", err.Error())
+			t.Error("error on read: " + err.Error())
 		}
 		_, err = cr.Read(plaintext)
 		if err != nil {
-			t.Errorf("error on read: %s", err.Error())
+			t.Error("error on read: " + err.Error())
 		}
 
 		aead, err := New(key[:])

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -386,7 +386,7 @@ func (c *MConnection) TrySend(chID byte, msgBytes []byte) bool {
 		return false
 	}
 
-	c.Logger.Debug("TrySend", "channel", chID, "conn", c, "msgBytes", fmt.Sprintf("%X", msgBytes))
+	// c.Logger.Debug("TrySend", "channel", chID, "conn", c, "msgBytes", fmt.Sprintf("%X", msgBytes))
 
 	// Send message to channel.
 	channel, ok := c.channelsIdx[chID]

--- a/types/block.go
+++ b/types/block.go
@@ -146,6 +146,10 @@ func (b *Block) Hash() tmbytes.HexBytes {
 	return b.Header.Hash()
 }
 
+func (b *Block) BlockID(partSetHeader PartSetHeader) BlockID {
+	return BlockID{Hash: b.Hash(), PartSetHeader: partSetHeader}
+}
+
 // MakePartSet returns a PartSet containing parts of a serialized block.
 // This is the form in which the block is gossipped to peers.
 // CONTRACT: partSize is greater than zero.


### PR DESCRIPTION
## Issue being fixed or feature implemented

Network got stuck due to outdated proposal block.

If the proposal block is older than time set in `proposed_block_time_window`, the network refuses to vote on it and votes NIL instead. This causes the network to freeze.

Visible result is that the network is frozen at some height, while creating new rounds over and over.

## What was done?

* check if the proposal block is expired, and regenerate it if needed
* added test to check this condition

## How Has This Been Tested?

* run unit tests

## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
