### PR TITLE
fix: data-race when sending a message from consensus/reactor to a peer via p2p.Channel

### DIFF
--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +15,10 @@ import (
 	tmtime "github.com/tendermint/tendermint/libs/time"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
+)
+
+var (
+	errPeerClosed = errors.New("peer is closed")
 )
 
 // peerStateStats holds internal statistics for a peer.

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -683,11 +683,6 @@ func (r *Reactor) broadcast(channel *p2p.Channel, msg proto.Message) error {
 	case <-r.closeCh:
 		return errReactorClosed
 	default:
-	}
-	select {
-	case <-r.closeCh:
-		return errReactorClosed
-	default:
 		return channel.Send(p2p.Envelope{
 			Broadcast: true,
 			Message:   msg,

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -672,12 +672,11 @@ func (r *Reactor) send(ps *PeerState, channel *p2p.Channel, msg proto.Message) e
 	case <-r.closeCh:
 		return errReactorClosed
 	default:
-		channel.Send(p2p.Envelope{
+		return channel.Send(p2p.Envelope{
 			To:      ps.peerID,
 			Message: msg,
 		})
 	}
-	return nil
 }
 
 // broadcast sends a broadcast message to all peers connected to the `channel`.
@@ -694,12 +693,12 @@ func (r *Reactor) broadcast(channel *p2p.Channel, msg proto.Message) error {
 		return p2p.ErrPeerChannelClosed
 	case <-r.closeCh:
 		return errReactorClosed
-	case channel.Out <- p2p.Envelope{
-		Broadcast: true,
-		Message:   msg,
-	}:
+	default:
+		return channel.Send(p2p.Envelope{
+			Broadcast: true,
+			Message:   msg,
+		})
 	}
-	return nil
 }
 
 // logResult creates a log that depends on value of err

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -672,18 +672,10 @@ func (r *Reactor) send(ps *PeerState, channel *p2p.Channel, msg proto.Message) e
 	case <-r.closeCh:
 		return errReactorClosed
 	default:
-	}
-	select {
-	case <-channel.Done():
-		return p2p.ErrPeerChannelClosed
-	case <-ps.closer.Done():
-		return errPeerClosed
-	case <-r.closeCh:
-		return errReactorClosed
-	case channel.Out <- p2p.Envelope{
-		To:      ps.peerID,
-		Message: msg,
-	}:
+		channel.Send(p2p.Envelope{
+			To:      ps.peerID,
+			Message: msg,
+		})
 	}
 	return nil
 }

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -665,8 +665,6 @@ func (r *Reactor) sendCommit(ps *PeerState, commit *types.Commit) error {
 // If to is nil, message will be broadcasted.
 func (r *Reactor) send(ps *PeerState, channel *p2p.Channel, msg proto.Message) error {
 	select {
-	case <-channel.Done():
-		return p2p.ErrPeerChannelClosed
 	case <-ps.closer.Done():
 		return errPeerClosed
 	case <-r.closeCh:
@@ -682,15 +680,11 @@ func (r *Reactor) send(ps *PeerState, channel *p2p.Channel, msg proto.Message) e
 // broadcast sends a broadcast message to all peers connected to the `channel`.
 func (r *Reactor) broadcast(channel *p2p.Channel, msg proto.Message) error {
 	select {
-	case <-channel.Done():
-		return p2p.ErrPeerChannelClosed
 	case <-r.closeCh:
 		return errReactorClosed
 	default:
 	}
 	select {
-	case <-channel.Done():
-		return p2p.ErrPeerChannelClosed
 	case <-r.closeCh:
 		return errReactorClosed
 	default:

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -69,9 +69,9 @@ type Channel struct {
 	Out   chan<- Envelope  // outbound messages (reactors to peers)
 	Error chan<- PeerError // peer error reporting
 
+	mtx         sync.RWMutex
 	messageType proto.Message // the channel's message type, used for unmarshaling
 	closeCh     chan struct{}
-	closeOnce   sync.Once
 }
 
 // NewChannel creates a new channel. It is primarily for internal and test
@@ -93,15 +93,33 @@ func NewChannel(
 	}
 }
 
+// Send sends an envelope to a peer through a channel
+func (c *Channel) Send(e Envelope) error {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	select {
+	case <-c.closeCh:
+		return ErrPeerChannelClosed
+	default:
+		c.Out <- e
+	}
+	return nil
+}
+
 // Close closes the channel. Future sends on Out and Error will panic. The In
 // channel remains open to avoid having to synchronize Router senders, which
 // should use Done() to detect channel closure instead.
 func (c *Channel) Close() {
-	c.closeOnce.Do(func() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	select {
+	case <-c.closeCh:
+		return
+	default:
 		close(c.closeCh)
 		close(c.Out)
 		close(c.Error)
-	})
+	}
 }
 
 // Done returns a channel that's closed when Channel.Close() is called.

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -21,6 +21,11 @@ import (
 
 const queueBufferDefault = 32
 
+var (
+	// ErrPeerChannelClosed is for when the send/receive an envelope but a peer was already disconnected
+	ErrPeerChannelClosed = errors.New("a peer channel is closed")
+)
+
 // ChannelID is an arbitrary channel ID.
 type ChannelID uint16
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After some refactoring in `refactor/consensus-reactor-send-broadcast` branch. 
there was detected data-race between reading data from GO channel and closing it.

## What was done?
<!--- Describe your changes in detail -->
To solve the data-race issue in `p2p.Channel` was added an additional `select` block to check, were channel,  a peer, or a reactor close to stopping sending a message

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
