### PR TITLE
fix: remove select block to don't block sending a witness response

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -757,12 +757,9 @@ func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) 
 		wg.Add(1)
 		go func(witnessIndex int, witnessResponsesC chan witnessResponse) {
 			defer wg.Done()
-
-			lb, err := c.witnesses[witnessIndex].LightBlock(ctx, height)
-			select {
-			case witnessResponsesC <- witnessResponse{lb, witnessIndex, err}:
-			case <-ctx.Done():
-			}
+			resp := witnessResponse{witnessIndex: witnessIndex}
+			resp.lb, resp.err = c.witnesses[witnessIndex].LightBlock(ctx, height)
+			witnessResponsesC <- resp
 		}(index, witnessResponsesC)
 	}
 

--- a/light/client.go
+++ b/light/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/tendermint/tendermint/crypto"
@@ -747,16 +746,13 @@ func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) 
 		witnessResponsesC = make(chan witnessResponse, len(c.witnesses))
 		witnessesToRemove []int
 		lastError         error
-		wg                sync.WaitGroup
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// send out a light block request to all witnesses
 	for index := range c.witnesses {
-		wg.Add(1)
 		go func(witnessIndex int, witnessResponsesC chan witnessResponse) {
-			defer wg.Done()
 			resp := witnessResponse{witnessIndex: witnessIndex}
 			resp.lb, resp.err = c.witnesses[witnessIndex].LightBlock(ctx, height)
 			witnessResponsesC <- resp
@@ -769,10 +765,6 @@ func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) 
 		switch response.err {
 		// success! We have found a new primary
 		case nil:
-			cancel() // cancel all remaining requests to other witnesses
-
-			wg.Wait() // wait for all goroutines to finish
-
 			// if we are not intending on removing the primary then append the old primary to the end of the witness slice
 			if !remove {
 				c.witnesses = append(c.witnesses, c.primary)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After backport v0.35.2 a test `TestClientHandlesContexts` became flaky

## What was done?
<!--- Describe your changes in detail -->
Removed select block to don't block sending a witness response.
_This bug came from upstream_

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `TestClientHandlesContexts`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
