### PR TITLE
fix(consensus): unsupported priv validator type - dashcore.RPCClient

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -433,8 +433,8 @@ func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 		State: defaultPrivValStatePath,
 
 		CoreRPCHost:     "",
-		CoreRPCUsername: "",
-		CoreRPCPassword: "",
+		CoreRPCUsername: "rpcuser",
+		CoreRPCPassword: "rpcpassword",
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -233,16 +233,6 @@ type BaseConfig struct { //nolint: maligned
 	// Path to the JSON file containing the initial validator set and other meta data
 	Genesis string `mapstructure:"genesis-file"`
 
-	// RPC port for Tendermint to query for
-	// an external PrivValidator process
-	PrivValidatorCoreRPCHost string `mapstructure:"priv-validator-core-rpc-host"`
-
-	// RPC username for Dash Core
-	PrivValidatorCoreRPCUsername string `mapstructure:"priv-validator-core-rpc-username"`
-
-	// RPC password for Dash Core
-	PrivValidatorCoreRPCPassword string `mapstructure:"priv-validator-core-rpc-password"`
-
 	// A JSON file containing the private key to use for p2p authenticated encryption
 	NodeKey string `mapstructure:"node-key-file"`
 
@@ -259,40 +249,34 @@ type BaseConfig struct { //nolint: maligned
 // DefaultBaseConfig returns a default base configuration for a Tendermint node
 func DefaultBaseConfig() BaseConfig {
 	return BaseConfig{
-		Genesis:                      defaultGenesisJSONPath,
-		PrivValidatorCoreRPCHost:     "",
-		PrivValidatorCoreRPCUsername: "dashrpc",
-		PrivValidatorCoreRPCPassword: "rpcpassword",
-		NodeKey:                      defaultNodeKeyPath,
-		Mode:                         defaultMode,
-		Moniker:                      defaultMoniker,
-		ProxyApp:                     "tcp://127.0.0.1:26658",
-		ABCI:                         "socket",
-		LogLevel:                     DefaultLogLevel,
-		LogFormat:                    log.LogFormatPlain,
-		FilterPeers:                  false,
-		DBBackend:                    "goleveldb",
-		DBPath:                       "data",
+		Genesis:     defaultGenesisJSONPath,
+		NodeKey:     defaultNodeKeyPath,
+		Mode:        defaultMode,
+		Moniker:     defaultMoniker,
+		ProxyApp:    "tcp://127.0.0.1:26658",
+		ABCI:        "socket",
+		LogLevel:    DefaultLogLevel,
+		LogFormat:   log.LogFormatPlain,
+		FilterPeers: false,
+		DBBackend:   "goleveldb",
+		DBPath:      "data",
 	}
 }
 
 // SingleNodeBaseConfig returns a default base configuration for a Tendermint node
 func SingleNodeBaseConfig() BaseConfig {
 	return BaseConfig{
-		Genesis:                      defaultGenesisJSONPath,
-		PrivValidatorCoreRPCHost:     "",
-		PrivValidatorCoreRPCUsername: "",
-		PrivValidatorCoreRPCPassword: "",
-		NodeKey:                      defaultNodeKeyPath,
-		Mode:                         defaultMode,
-		Moniker:                      defaultMoniker,
-		ProxyApp:                     "tcp://127.0.0.1:26658",
-		ABCI:                         "socket",
-		LogLevel:                     DefaultLogLevel,
-		LogFormat:                    log.LogFormatPlain,
-		FilterPeers:                  false,
-		DBBackend:                    "goleveldb",
-		DBPath:                       "data",
+		Genesis:     defaultGenesisJSONPath,
+		NodeKey:     defaultNodeKeyPath,
+		Mode:        defaultMode,
+		Moniker:     defaultMoniker,
+		ProxyApp:    "tcp://127.0.0.1:26658",
+		ABCI:        "socket",
+		LogLevel:    DefaultLogLevel,
+		LogFormat:   log.LogFormatPlain,
+		FilterPeers: false,
+		DBBackend:   "goleveldb",
+		DBPath:      "data",
 	}
 }
 
@@ -303,7 +287,6 @@ func TestBaseConfig() BaseConfig {
 	cfg.Mode = ModeValidator
 	cfg.ProxyApp = "kvstore"
 	cfg.DBBackend = "memdb"
-	cfg.PrivValidatorCoreRPCHost = ""
 	return cfg
 }
 
@@ -430,6 +413,16 @@ type PrivValidatorConfig struct {
 
 	// Path Root Certificate Authority used to sign both client and server certificates
 	RootCA string `mapstructure:"root-ca-file"`
+
+	// RPC port for Tendermint to query for
+	// an external PrivValidator process
+	PrivValidatorCoreRPCHost string `mapstructure:"core-rpc-host"`
+
+	// RPC username for Dash Core
+	PrivValidatorCoreRPCUsername string `mapstructure:"core-rpc-username"`
+
+	// RPC password for Dash Core
+	PrivValidatorCoreRPCPassword string `mapstructure:"core-rpc-password"`
 }
 
 // DefaultBaseConfig returns a default private validator configuration
@@ -438,6 +431,10 @@ func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 	return &PrivValidatorConfig{
 		Key:   defaultPrivValKeyPath,
 		State: defaultPrivValStatePath,
+
+		PrivValidatorCoreRPCHost:     "",
+		PrivValidatorCoreRPCUsername: "",
+		PrivValidatorCoreRPCPassword: "",
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -416,13 +416,13 @@ type PrivValidatorConfig struct {
 
 	// RPC port for Tendermint to query for
 	// an external PrivValidator process
-	PrivValidatorCoreRPCHost string `mapstructure:"core-rpc-host"`
+	CoreRPCHost string `mapstructure:"core-rpc-host"`
 
 	// RPC username for Dash Core
-	PrivValidatorCoreRPCUsername string `mapstructure:"core-rpc-username"`
+	CoreRPCUsername string `mapstructure:"core-rpc-username"`
 
 	// RPC password for Dash Core
-	PrivValidatorCoreRPCPassword string `mapstructure:"core-rpc-password"`
+	CoreRPCPassword string `mapstructure:"core-rpc-password"`
 }
 
 // DefaultBaseConfig returns a default private validator configuration
@@ -432,9 +432,9 @@ func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 		Key:   defaultPrivValKeyPath,
 		State: defaultPrivValStatePath,
 
-		PrivValidatorCoreRPCHost:     "",
-		PrivValidatorCoreRPCUsername: "",
-		PrivValidatorCoreRPCPassword: "",
+		CoreRPCHost:     "",
+		CoreRPCUsername: "",
+		CoreRPCPassword: "",
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -167,13 +167,13 @@ laddr = "{{ .PrivValidator.ListenAddr }}"
 
 # Local Dash Core Host to connect to
 # If this is set, the node follows a Dash Core PrivValidator process
-priv-validator-core-rpc-host = "{{ .BaseConfig.PrivValidatorCoreRPCHost }}"
+core-rpc-host = "{{ .BaseConfig.PrivValidatorCoreRPCHost }}"
 
 # Local Dash Core RPC Username
-priv-validator-core-rpc-username = "{{ .BaseConfig.PrivValidatorCoreRPCUsername }}"
+core-rpc-username = "{{ .BaseConfig.PrivValidatorCoreRPCUsername }}"
 
 # Local Dash Core RPC Password
-priv-validator-core-rpc-password = "{{ .BaseConfig.PrivValidatorCoreRPCPassword }}"
+core-rpc-password = "{{ .BaseConfig.PrivValidatorCoreRPCPassword }}"
 
 # Path to the JSON file containing the private key to use for node authentication in the p2p protocol
 node-key-file = "{{ js .BaseConfig.NodeKey }}"

--- a/config/toml.go
+++ b/config/toml.go
@@ -167,13 +167,13 @@ laddr = "{{ .PrivValidator.ListenAddr }}"
 
 # Local Dash Core Host to connect to
 # If this is set, the node follows a Dash Core PrivValidator process
-core-rpc-host = "{{ .PrivValidator.PrivValidatorCoreRPCHost }}"
+core-rpc-host = "{{ .PrivValidator.CoreRPCHost }}"
 
 # Local Dash Core RPC Username
-core-rpc-username = "{{ .PrivValidator.PrivValidatorCoreRPCUsername }}"
+core-rpc-username = "{{ .PrivValidator.CoreRPCUsername }}"
 
 # Local Dash Core RPC Password
-core-rpc-password = "{{ .PrivValidator.PrivValidatorCoreRPCPassword }}"
+core-rpc-password = "{{ .PrivValidator.CoreRPCPassword }}"
 
 # Path to the client certificate generated while creating needed files for secure connection.
 # If a remote validator address is provided but no certificate, the connection will be insecure

--- a/config/toml.go
+++ b/config/toml.go
@@ -167,16 +167,13 @@ laddr = "{{ .PrivValidator.ListenAddr }}"
 
 # Local Dash Core Host to connect to
 # If this is set, the node follows a Dash Core PrivValidator process
-core-rpc-host = "{{ .BaseConfig.PrivValidatorCoreRPCHost }}"
+core-rpc-host = "{{ .PrivValidator.PrivValidatorCoreRPCHost }}"
 
 # Local Dash Core RPC Username
-core-rpc-username = "{{ .BaseConfig.PrivValidatorCoreRPCUsername }}"
+core-rpc-username = "{{ .PrivValidator.PrivValidatorCoreRPCUsername }}"
 
 # Local Dash Core RPC Password
-core-rpc-password = "{{ .BaseConfig.PrivValidatorCoreRPCPassword }}"
-
-# Path to the JSON file containing the private key to use for node authentication in the p2p protocol
-node-key-file = "{{ js .BaseConfig.NodeKey }}"
+core-rpc-password = "{{ .PrivValidator.PrivValidatorCoreRPCPassword }}"
 
 # Path to the client certificate generated while creating needed files for secure connection.
 # If a remote validator address is provided but no certificate, the connection will be insecure

--- a/dash/quorum/validator_conn_executor.go
+++ b/dash/quorum/validator_conn_executor.go
@@ -131,8 +131,9 @@ func (vc *ValidatorConnExecutor) OnStart() error {
 	}
 	err := vc.updateConnections()
 	if err != nil {
-		return err
+		vc.Logger.Error("Warning: ValidatorConnExecutor OnStart failed", "error", err)
 	}
+
 	go func() {
 		var err error
 		for err == nil {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -330,6 +330,8 @@ func (cs *State) SetPrivValidator(priv types.PrivValidator) {
 			cs.privValidatorType = types.MockSignerClient
 		case *types.ErroringMockPV:
 			cs.privValidatorType = types.ErrorMockSignerClient
+		case *privval.DashCoreSignerClient:
+			cs.privValidatorType = types.DashCoreRPCClient
 		default:
 			cs.Logger.Error("unsupported priv validator type", "err",
 				fmt.Errorf("error privValidatorType %s", t))

--- a/node/node.go
+++ b/node/node.go
@@ -184,7 +184,7 @@ func makeNode(cfg *config.Config,
 
 	var proTxHash crypto.ProTxHash
 	switch {
-	case cfg.PrivValidatorCoreRPCHost != "":
+	case cfg.PrivValidator.PrivValidatorCoreRPCHost != "":
 		logger.Info(
 			"Initializing Dash Core Signing",
 			"quorum hash",
@@ -603,9 +603,9 @@ func makeNode(cfg *config.Config,
 // DefaultDashCoreRPCClient returns RPC client for the Dash Core node
 func DefaultDashCoreRPCClient(cfg *config.Config, logger log.Logger) (dashcore.Client, error) {
 	return dashcore.NewRPCClient(
-		cfg.PrivValidatorCoreRPCHost,
-		cfg.BaseConfig.PrivValidatorCoreRPCUsername,
-		cfg.BaseConfig.PrivValidatorCoreRPCPassword,
+		cfg.PrivValidator.PrivValidatorCoreRPCHost,
+		cfg.PrivValidator.PrivValidatorCoreRPCUsername,
+		cfg.PrivValidator.PrivValidatorCoreRPCPassword,
 		logger,
 	)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -211,7 +211,7 @@ func makeNode(cfg *config.Config,
 				logger,
 			)
 			if err != nil {
-				return nil, fmt.Errorf("error with private validator socket client: %w", err)
+				return nil, fmt.Errorf("error with private validator RPC client: %w", err)
 			}
 			proTxHash, err = privValidator.GetProTxHash(context.TODO())
 			if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -184,7 +184,7 @@ func makeNode(cfg *config.Config,
 
 	var proTxHash crypto.ProTxHash
 	switch {
-	case cfg.PrivValidator.PrivValidatorCoreRPCHost != "":
+	case cfg.PrivValidator.CoreRPCHost != "":
 		logger.Info(
 			"Initializing Dash Core Signing",
 			"quorum hash",
@@ -603,9 +603,9 @@ func makeNode(cfg *config.Config,
 // DefaultDashCoreRPCClient returns RPC client for the Dash Core node
 func DefaultDashCoreRPCClient(cfg *config.Config, logger log.Logger) (dashcore.Client, error) {
 	return dashcore.NewRPCClient(
-		cfg.PrivValidator.PrivValidatorCoreRPCHost,
-		cfg.PrivValidator.PrivValidatorCoreRPCUsername,
-		cfg.PrivValidator.PrivValidatorCoreRPCPassword,
+		cfg.PrivValidator.CoreRPCHost,
+		cfg.PrivValidator.CoreRPCUsername,
+		cfg.PrivValidator.CoreRPCPassword,
 		logger,
 	)
 }

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -97,8 +97,8 @@ func run(configFile string) error {
 
 			dashCoreRPCClient, err = dashcore.NewRPCClient(
 				cfg.PrivValServer,
-				tmcfg.BaseConfig.PrivValidatorCoreRPCUsername,
-				tmcfg.BaseConfig.PrivValidatorCoreRPCPassword,
+				tmcfg.PrivValidator.PrivValidatorCoreRPCUsername,
+				tmcfg.PrivValidator.PrivValidatorCoreRPCPassword,
 				logger.With("module", dashcore.ModuleName),
 			)
 			if err != nil {

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -97,8 +97,8 @@ func run(configFile string) error {
 
 			dashCoreRPCClient, err = dashcore.NewRPCClient(
 				cfg.PrivValServer,
-				tmcfg.PrivValidator.PrivValidatorCoreRPCUsername,
-				tmcfg.PrivValidator.PrivValidatorCoreRPCPassword,
+				tmcfg.PrivValidator.CoreRPCUsername,
+				tmcfg.PrivValidator.CoreRPCPassword,
 				logger.With("module", dashcore.ModuleName),
 			)
 			if err != nil {

--- a/test/e2e/pkg/utils.go
+++ b/test/e2e/pkg/utils.go
@@ -96,9 +96,6 @@ func updateGenesisValidators(testnet *Testnet) initValidatorFunc {
 
 func updatePrivvalUpdateHeights(height int, quorumHash crypto.QuorumHash) initNodeFunc {
 	return func(node *Node) error {
-		if height == 0 {
-			return nil
-		}
 		if node.PrivvalUpdateHeights == nil {
 			node.PrivvalUpdateHeights = make(map[string]crypto.QuorumHash)
 		}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -331,7 +331,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.PrivValidator.State = PrivvalDummyStateFile
 
 	if node.PrivvalProtocol == e2e.ProtocolDashCore {
-		cfg.PrivValidatorCoreRPCHost = "127.0.0.1:19998"
+		cfg.PrivValidator.PrivValidatorCoreRPCHost = "127.0.0.1:19998"
 	}
 
 	switch node.Mode {

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -331,7 +331,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.PrivValidator.State = PrivvalDummyStateFile
 
 	if node.PrivvalProtocol == e2e.ProtocolDashCore {
-		cfg.PrivValidator.PrivValidatorCoreRPCHost = "127.0.0.1:19998"
+		cfg.PrivValidator.CoreRPCHost = "127.0.0.1:19998"
 	}
 
 	switch node.Mode {

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -28,6 +28,7 @@ const (
 	SignerSocketClient    = PrivValidatorType(0x03) // signer client via socket
 	ErrorMockSignerClient = PrivValidatorType(0x04) // error mock signer
 	SignerGRPCClient      = PrivValidatorType(0x05) // signer client via gRPC
+	DashCoreRPCClient     = PrivValidatorType(0x06) // signer client via gRPC
 )
 
 // PrivValidator defines the functionality of a local Tendermint validator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Tenderdash didn't start in configuration where privval is implemented by Dash Core.
Also, some config options are misplaced.

## What was done?

1. Added support for `privval.DashCoreSignerClient`
2. Moved core priv validator settings to `[priv-validator]` section
3. Failure to execute ValidatorConnExecutor is not stopping startup of tenderdash anymore.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
