### PR TITLE
chore: clone bls library if tenderdash is not tracked by git

### DIFF
--- a/third_party/bls-signatures/build.sh
+++ b/third_party/bls-signatures/build.sh
@@ -3,8 +3,17 @@
 SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 SRC_PATH="$SCRIPT_PATH/src"
 BUILD_PATH="$SCRIPT_PATH/build"
+BLS_SM_PATH="third_party/bls-signatures/src"
+BLS_GIT_REPO="https://github.com/dashpay/bls-signatures.git"
+BLS_GIT_BRANCH="develop_0.1"
 
-git submodule update --init third_party/bls-signatures/src
+git submodule update --init $BLS_SM_PATH
+if [ $? -ne 0 ]; then
+	echo "It looks like this source code is not tracked by git."
+	echo "As a fallback scenario we will fetch \"$BLS_GIT_BRANCH\" branch \"$BLS_GIT_REPO\" library."
+	echo "We would recommend to clone of this project rather than using a release archive."
+	git clone --single-branch --branch $BLS_GIT_BRANCH $BLS_GIT_REPO $BLS_SM_PATH
+fi
 
 # Create folders for source and build data
 mkdir -p $BUILD_PATH


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* This fix is a result of reported issue #351 
* Since a release source code archive is not tracked by git, then to build a project we need support a way of obtaining bls-signature submodule

## What was done?
<!--- Describe your changes in detail -->
if the tenderdash source code is not tracked by git then:
* Display a message about fallback scenario
* Clone "develop_0.1" single branch to be able to build a project

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build the project locally from archive

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
