### PR TITLE
fix: change a way of interacting with p2p channels in consensus reactor

### DIFF
--- a/internal/consensus/invalid_test.go
+++ b/internal/consensus/invalid_test.go
@@ -116,13 +116,12 @@ func invalidDoPrevoteFunc(t *testing.T, height int64, round int32, cs *State, r 
 
 		for _, ps := range r.peers {
 			cs.Logger.Info("sending bad vote", "block", blockHash, "peer", ps.peerID)
-
-			r.voteCh.Out <- p2p.Envelope{
+			_ = r.voteCh.Send(p2p.Envelope{
 				To: ps.peerID,
 				Message: &tmcons.Vote{
 					Vote: precommit.ToProto(),
 				},
-			}
+			})
 		}
 	}()
 }

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -1421,7 +1421,10 @@ func (r *Reactor) processMsgCh(msgCh *p2p.Channel) {
 	defer msgCh.Close()
 	for {
 		select {
-		case envelope := <-msgCh.In:
+		case <-r.closeCh:
+			return
+		default:
+			envelope := <-msgCh.In
 			if err := r.handleMessage(msgCh.ID, envelope); err != nil {
 				r.Logger.Error("failed to process message", "ch_id", msgCh.ID, "envelope", envelope, "err", err)
 				msgCh.Error <- p2p.PeerError{
@@ -1429,8 +1432,6 @@ func (r *Reactor) processMsgCh(msgCh *p2p.Channel) {
 					Err:    err,
 				}
 			}
-		case <-r.closeCh:
-			return
 		}
 	}
 }

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -189,11 +189,7 @@ func (blockExec *BlockExecutor) ValidateBlock(state State, block *types.Block) e
 // Validation does not mutate state, but does require historical information from the stateDB,
 // ie. to verify evidence from a validator at an old height.
 func (blockExec *BlockExecutor) ValidateBlockChainLock(state State, block *types.Block) error {
-	err := validateBlockChainLock(blockExec.queryApp, state, block)
-	if err != nil {
-		return err
-	}
-	return err
+	return validateBlockChainLock(blockExec.queryApp, state, block)
 }
 
 // ValidateBlockTime validates the given block time against the given state.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Detected data-race https://github.com/dashevo/tenderdash/runs/6110751227?check_suite_focus=true
```
WARNING: DATA RACE
Read at 0x00c000519bd0 by goroutine 85:
  runtime.chansend()
      /opt/hostedtoolcache/go/1.17.8/x64/src/runtime/chan.go:158 +0x0
  github.com/tendermint/tendermint/internal/consensus.invalidDoPrevoteFunc.func1()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/invalid_test.go:120 +0xe55

Previous write at 0x00c000519bd0 by goroutine 130:
  runtime.closechan()
      /opt/hostedtoolcache/go/1.17.8/x64/src/runtime/chan.go:355 +0x0
  github.com/tendermint/tendermint/internal/p2p.(*Channel).Close()
      /home/runner/work/tenderdash/tenderdash/internal/p2p/router.go:120 +0x11b
  github.com/tendermint/tendermint/internal/consensus.(*Reactor).processMsgCh·dwrap·52()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/reactor.go:1421 +0x39
  github.com/tendermint/tendermint/internal/consensus.(*Reactor).processMsgCh()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/reactor.go:1433 +0x616
  github.com/tendermint/tendermint/internal/consensus.(*Reactor).OnStart·dwrap·31()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/reactor.go:217 +0x47

Goroutine 85 (running) created at:
  github.com/tendermint/tendermint/internal/consensus.invalidDoPrevoteFunc()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/invalid_test.go:78 +0x164
  github.com/tendermint/tendermint/internal/consensus.TestReactorInvalidPrecommit.func1()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/invalid_test.go:51 +0x7e
  github.com/tendermint/tendermint/internal/consensus.(*State).enterPrevote()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/state.go:1470 +0x7da
  github.com/tendermint/tendermint/internal/consensus.(*State).addProposalBlockPart()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/state.go:2397 +0x218f
  github.com/tendermint/tendermint/internal/consensus.(*State).handleMsg()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/state.go:959 +0x204
  github.com/tendermint/tendermint/internal/consensus.(*State).receiveRoutine()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/state.go:902 +0x6c7
  github.com/tendermint/tendermint/internal/consensus.(*State).OnStart·dwrap·65()
      /home/runner/work/tenderdash/tenderdash/internal/consensus/state.go:448 +0x47
```

## What was done?
<!--- Describe your changes in detail -->
* Use a safe way `p2p.Channel.Send()` to send a message into a channel
* Change a way of reading from p2p channels in consensus reactor

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
