### PR TITLE
fix: add a missed "info" field to broadcast-tx-response

### DIFF
--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -53,6 +53,7 @@ func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*co
 		Log:          r.Log,
 		Codespace:    r.Codespace,
 		MempoolError: r.MempoolError,
+		Info:         r.Info,
 		Hash:         tx.Hash(),
 	}, nil
 }

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -205,6 +205,7 @@ type ResultBroadcastTx struct {
 	Log          string         `json:"log"`
 	Codespace    string         `json:"codespace"`
 	MempoolError string         `json:"mempool_error"`
+	Info         string         `json:"info"`
 
 	Hash bytes.HexBytes `json:"hash"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@jawid-h reported about missed "info" field in a response on a `broadcast-tx--sync` request

## What was done?
<!--- Describe your changes in detail -->
Added `info` field to a response, data takes from a abci response

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
