### PR TITLE
refactor: decouple dash's parameters in a MakeBlock function to be compatible with upstream

### DIFF
--- a/dash/quorum/validator_conn_executor_test.go
+++ b/dash/quorum/validator_conn_executor_test.go
@@ -640,8 +640,8 @@ func makeState(nVals int, height int64) (sm.State, dbm.DB, map[string]types.Priv
 
 func makeBlock(state sm.State, height int64, commit *types.Commit) *types.Block {
 	return state.MakeBlock(
-		height, nil, makeTxs(state.LastBlockHeight),
-		commit, nil, state.Validators.GetProposer().ProTxHash, 0,
+		height, makeTxs(state.LastBlockHeight),
+		commit, nil, state.Validators.GetProposer().ProTxHash,
 	)
 }
 

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -180,8 +180,9 @@ func (rts *reactorTestSuite) addNode(
 			)
 		}
 
-		thisBlock, err := sf.MakeBlock(state, blockHeight, lastCommit, nil, 0)
+		thisBlock, err := sf.MakeBlock(state, blockHeight, lastCommit)
 		require.NoError(t, err)
+		thisBlock.SetDashParams(state.LastCoreChainLockedBlockHeight, nil, 0)
 		thisParts, err := thisBlock.MakePartSet(types.BlockPartSizeBytes)
 		require.NoError(t, err)
 		blockID := types.BlockID{Hash: thisBlock.Hash(), PartSetHeader: thisParts.Header()}

--- a/internal/eventbus/event_bus_test.go
+++ b/internal/eventbus/event_bus_test.go
@@ -81,7 +81,8 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 
-	block := types.MakeBlock(0, 0, nil, []types.Tx{}, nil, []types.Evidence{}, 1)
+	block := types.MakeBlock(0, []types.Tx{}, nil, []types.Evidence{})
+	block.SetDashParams(0, nil, 1)
 	bps, err := block.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
@@ -253,7 +254,8 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 
-	block := types.MakeBlock(0, 0, nil, []types.Tx{}, nil, []types.Evidence{}, 1)
+	block := types.MakeBlock(0, []types.Tx{}, nil, []types.Evidence{})
+	block.SetDashParams(0, nil, 1)
 	resultFinalizeBlock := abci.ResponseFinalizeBlock{
 		Events: []abci.Event{
 			{Type: "testType", Attributes: []abci.EventAttribute{

--- a/internal/evidence/pool_test.go
+++ b/internal/evidence/pool_test.go
@@ -262,7 +262,8 @@ func TestEvidencePoolUpdate(t *testing.T) {
 	lastCommit := makeCommit(height, state.Validators.QuorumHash, val.ProTxHash)
 
 	coreChainLockHeight := state.LastCoreChainLockedBlockHeight
-	block := types.MakeBlock(height+1, coreChainLockHeight, nil, []types.Tx{}, lastCommit, []types.Evidence{ev}, 0)
+	block := types.MakeBlock(height+1, []types.Tx{}, lastCommit, []types.Evidence{ev})
+	block.SetDashParams(coreChainLockHeight, nil, 0)
 
 	// update state (partially)
 	state.LastBlockHeight = height + 1
@@ -541,7 +542,7 @@ func initializeBlockStore(db dbm.DB, state sm.State, valProTxHash []byte) (*stor
 
 	for i := int64(1); i <= state.LastBlockHeight; i++ {
 		lastCommit := makeCommit(i-1, state.Validators.QuorumHash, valProTxHash)
-		block := state.MakeBlock(i, nil, []types.Tx{}, lastCommit, nil, state.Validators.GetProposer().ProTxHash, 0)
+		block := state.MakeBlock(i, []types.Tx{}, lastCommit, nil, state.Validators.GetProposer().ProTxHash)
 
 		block.Header.Time = defaultEvidenceTime.Add(time.Duration(i) * time.Minute)
 		block.Header.Version = version.Consensus{Block: version.BlockProtocol, App: 1}

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -121,7 +121,8 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	}
 
 	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas)
-	block := state.MakeBlock(height, nextCoreChainLock, txs, commit, evidence, proposerProTxHash, proposedAppVersion)
+	block := state.MakeBlock(height, txs, commit, evidence, proposerProTxHash)
+	block.SetDashParams(state.LastCoreChainLockedBlockHeight, nextCoreChainLock, proposedAppVersion)
 
 	localLastCommit := buildLastCommitInfo(block, blockExec.store, state.InitialHeight)
 	rpp, err := blockExec.appClient.PrepareProposal(
@@ -164,16 +165,15 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 		}
 	}
 	itxs := txrSet.IncludedTxs()
-
-	return state.MakeBlock(
+	block = state.MakeBlock(
 		height,
-		nextCoreChainLock,
 		itxs,
 		commit,
 		evidence,
 		proposerProTxHash,
-		proposedAppVersion,
-	), nil
+	)
+	block.SetDashParams(state.LastCoreChainLockedBlockHeight, nextCoreChainLock, proposedAppVersion)
+	return block, nil
 }
 
 func (blockExec *BlockExecutor) ProcessProposal(

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -81,7 +81,7 @@ func TestApplyBlock(t *testing.T) {
 		sm.NopMetrics(),
 	)
 
-	block, err := sf.MakeBlock(state, 1, new(types.Commit), nil, 0)
+	block, err := sf.MakeBlock(state, 1, new(types.Commit))
 	require.NoError(t, err)
 	bps, err := block.MakePartSet(testPartSize)
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestFinalizeBlockByzantineValidators(t *testing.T) {
 
 	blockExec := sm.NewBlockExecutor(stateStore, log.NewNopLogger(), proxyApp, mp, evpool, blockStore, eventBus, sm.NopMetrics())
 
-	block, err := sf.MakeBlock(state, 1, new(types.Commit), nil, 1)
+	block, err := sf.MakeBlock(state, 1, new(types.Commit))
 	require.NoError(t, err)
 	block.Evidence = ev
 	block.Header.EvidenceHash = block.Evidence.Hash()
@@ -228,7 +228,7 @@ func TestProcessProposal(t *testing.T) {
 	//}
 
 	lastCommit := types.NewCommit(height-1, 0, types.BlockID{}, types.StateID{}, nil)
-	block1, err := sf.MakeBlock(state, height, lastCommit, nil, 0)
+	block1, err := sf.MakeBlock(state, height, lastCommit)
 	require.NoError(t, err)
 	block1.Txs = txs
 
@@ -475,7 +475,7 @@ func TestFinalizeBlockValidatorUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	block, err := sf.MakeBlock(state, 1, new(types.Commit), nil, 0)
+	block, err := sf.MakeBlock(state, 1, new(types.Commit))
 	require.NoError(t, err)
 	bps, err := block.MakePartSet(testPartSize)
 	require.NoError(t, err)
@@ -566,7 +566,7 @@ func TestFinalizeBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 		sm.NopMetrics(),
 	)
 
-	block, err := sf.MakeBlock(state, 1, new(types.Commit), nil, 0)
+	block, err := sf.MakeBlock(state, 1, new(types.Commit))
 	require.NoError(t, err)
 	bps, err := block.MakePartSet(testPartSize)
 	require.NoError(t, err)

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -64,7 +64,8 @@ func makeAndApplyGoodBlock(
 	proposedAppVersion uint64,
 ) (sm.State, types.BlockID) {
 	t.Helper()
-	block := state.MakeBlock(height, nil, factory.MakeNTxs(height, 10), lastCommit, evidence, proposerProTxHash, proposedAppVersion)
+	block := state.MakeBlock(height, factory.MakeNTxs(height, 10), lastCommit, evidence, proposerProTxHash)
+	block.SetDashParams(state.LastCoreChainLockedBlockHeight, nil, proposedAppVersion)
 	partSet, err := block.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
 
@@ -145,7 +146,7 @@ func makeHeaderPartsResponsesValPowerChange(
 ) (types.Header, *types.CoreChainLock, types.BlockID, *tmstate.ABCIResponses) {
 	t.Helper()
 
-	block, err := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit), nil, 0)
+	block, err := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	require.NoError(t, err)
 
 	abciResponses := &tmstate.ABCIResponses{}
@@ -174,7 +175,7 @@ func makeHeaderPartsResponsesValPowerChange(
 }
 
 func makeHeaderPartsResponsesValKeysRegenerate(t *testing.T, state sm.State, regenerate bool) (types.Header, *types.CoreChainLock, types.BlockID, *tmstate.ABCIResponses) {
-	block, err := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit), nil, 0)
+	block, err := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	if err != nil {
 		t.Error(err)
 	}
@@ -198,7 +199,7 @@ func makeHeaderPartsResponsesParams(
 ) (types.Header, *types.CoreChainLock, types.BlockID, *tmstate.ABCIResponses) {
 	t.Helper()
 
-	block, err := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit), nil, 0)
+	block, err := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	require.NoError(t, err)
 	pbParams := params.ToProto()
 	abciResponses := &tmstate.ABCIResponses{

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -302,23 +302,14 @@ func FromProto(pb *tmstate.State) (*State, error) { //nolint:golint
 // track rounds, and hence does not know the correct proposer. TODO: fix this!
 func (state State) MakeBlock(
 	height int64,
-	coreChainLock *types.CoreChainLock,
 	txs []types.Tx,
 	commit *types.Commit,
 	evidence []types.Evidence,
 	proposerProTxHash types.ProTxHash,
-	proposedAppVersion uint64,
 ) *types.Block {
 
-	var coreChainLockHeight uint32
-	if coreChainLock == nil {
-		coreChainLockHeight = state.LastCoreChainLockedBlockHeight
-	} else {
-		coreChainLockHeight = coreChainLock.CoreBlockHeight
-	}
-
 	// Build base block with block data.
-	block := types.MakeBlock(height, coreChainLockHeight, coreChainLock, txs, commit, evidence, proposedAppVersion)
+	block := types.MakeBlock(height, txs, commit, evidence)
 
 	// Fill rest of header with state data.
 	block.Header.Populate(

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -113,7 +113,7 @@ func TestABCIResponsesSaveLoad1(t *testing.T) {
 	state.LastBlockHeight++
 
 	// Build mock responses.
-	block, err := statefactory.MakeBlock(state, 2, new(types.Commit), nil, 0)
+	block, err := statefactory.MakeBlock(state, 2, new(types.Commit))
 	require.NoError(t, err)
 
 	abciResponses := new(tmstate.ABCIResponses)
@@ -461,7 +461,7 @@ func TestProposerPriorityDoesNotGetResetToZero(t *testing.T) {
 	// NewValidatorSet calls IncrementProposerPriority but uses on a copy of val1
 	assert.EqualValues(t, 0, val1.ProposerPriority)
 
-	block, err := statefactory.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit), nil, 0)
+	block, err := statefactory.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	require.NoError(t, err)
 	blockID, err := block.BlockID()
 	require.NoError(t, err)
@@ -599,7 +599,7 @@ func TestProposerPriorityProposerAlternates(t *testing.T) {
 	// we only have one validator:
 	assert.Equal(t, val1ProTxHash, state.Validators.Proposer.ProTxHash)
 
-	block, err := statefactory.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit), nil, 0)
+	block, err := statefactory.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	require.NoError(t, err)
 	blockID, err := block.BlockID()
 	require.NoError(t, err)
@@ -974,7 +974,7 @@ func TestStateMakeBlock(t *testing.T) {
 	stateVersion := state.Version.Consensus
 	var height int64 = 2
 	state.LastBlockHeight = height - 1
-	block, err := statefactory.MakeBlock(state, height, new(types.Commit), nil, 0)
+	block, err := statefactory.MakeBlock(state, height, new(types.Commit))
 	require.NoError(t, err)
 
 	// test we set some fields
@@ -1119,7 +1119,7 @@ func blockExecutorFunc(t *testing.T, firstProTxHash crypto.ProTxHash) func(prevS
 		validatorUpdates, thresholdPubKey, quorumHash, err :=
 			types.PB2TM.ValidatorUpdatesFromValidatorSet(resp.FinalizeBlock.ValidatorSetUpdate)
 		require.NoError(t, err)
-		block, err := statefactory.MakeBlock(prevState, prevState.LastBlockHeight+1, new(types.Commit), nil, 0)
+		block, err := statefactory.MakeBlock(prevState, prevState.LastBlockHeight+1, new(types.Commit))
 		require.NoError(t, err)
 		blockID, err := block.BlockID()
 		require.NoError(t, err)

--- a/internal/state/test/factory/block.go
+++ b/internal/state/test/factory/block.go
@@ -45,18 +45,16 @@ func MakeBlocks(ctx context.Context, t *testing.T, n int, state *sm.State, privV
 	return blocks
 }
 
-func MakeBlock(state sm.State, height int64, c *types.Commit, coreChainLock *types.CoreChainLock, proposedAppVersion uint64) (*types.Block, error) {
+func MakeBlock(state sm.State, height int64, c *types.Commit) (*types.Block, error) {
 	if state.LastBlockHeight != (height - 1) {
 		return nil, fmt.Errorf("requested height %d should be 1 more than last block height %d", height, state.LastBlockHeight)
 	}
 	return state.MakeBlock(
 		height,
-		coreChainLock,
 		factory.MakeNTxs(state.LastBlockHeight, 10),
 		c,
 		nil,
 		state.Validators.GetProposer().ProTxHash,
-		proposedAppVersion,
 	), nil
 }
 
@@ -98,7 +96,7 @@ func makeBlockAndPartSet(
 		)
 	}
 
-	block := state.MakeBlock(height, nil, []types.Tx{}, lastCommit, nil, state.Validators.GetProposer().ProTxHash, 0)
+	block := state.MakeBlock(height, []types.Tx{}, lastCommit, nil, state.Validators.GetProposer().ProTxHash)
 	partSet, err := block.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -91,7 +91,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	}
 
 	// save a block
-	block, err := factory.MakeBlock(state, bs.Height()+1, new(types.Commit), nil, 0)
+	block, err := factory.MakeBlock(state, bs.Height()+1, new(types.Commit))
 	require.NoError(t, err)
 	validPartSet, err := block.MakePartSet(2)
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestLoadBaseMeta(t *testing.T) {
 
 	for h := int64(1); h <= 10; h++ {
 		state.LastBlockHeight = h - 1
-		block, err := factory.MakeBlock(state, h, new(types.Commit), nil, 0)
+		block, err := factory.MakeBlock(state, h, new(types.Commit))
 		require.NoError(t, err)
 		partSet, err := block.MakePartSet(2)
 		require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestLoadBlockPart(t *testing.T) {
 	require.Contains(t, panicErr.Error(), "unmarshal to tmproto.Part failed")
 
 	// 3. A good block serialized and saved to the DB should be retrievable
-	block, err := factory.MakeBlock(state, 1, new(types.Commit), nil, 0)
+	block, err := factory.MakeBlock(state, 1, new(types.Commit))
 	require.NoError(t, err)
 	partSet, err := block.MakePartSet(2)
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestPruneBlocks(t *testing.T) {
 	// make more than 1000 blocks, to test batch deletions
 	for h := int64(1); h <= 1500; h++ {
 		state.LastBlockHeight = h - 1
-		block, err := factory.MakeBlock(state, h, new(types.Commit), nil, 0)
+		block, err := factory.MakeBlock(state, h, new(types.Commit))
 		require.NoError(t, err)
 		partSet, err := block.MakePartSet(2)
 		require.NoError(t, err)
@@ -487,7 +487,7 @@ func TestLoadBlockMeta(t *testing.T) {
 func TestBlockFetchAtHeight(t *testing.T) {
 	state, bs := makeStateAndBlockStore(t, t.TempDir())
 	require.Equal(t, bs.Height(), int64(0), "initially the height should be zero")
-	block, err := factory.MakeBlock(state, bs.Height()+1, new(types.Commit), nil, 0)
+	block, err := factory.MakeBlock(state, bs.Height()+1, new(types.Commit))
 	require.NoError(t, err)
 
 	partSet, err := block.MakePartSet(2)
@@ -531,7 +531,7 @@ func TestSeenAndCanonicalCommit(t *testing.T) {
 	for h := int64(3); h <= 5; h++ {
 		state.LastBlockHeight = h - 1
 		blockCommit := makeTestCommit(state, h-1, tmtime.Now())
-		block, err := factory.MakeBlock(state, h, blockCommit, nil, 0)
+		block, err := factory.MakeBlock(state, h, blockCommit)
 		require.NoError(t, err)
 		partSet, err := block.MakePartSet(2)
 		require.NoError(t, err)

--- a/proto/tendermint/blocksync/message_test.go
+++ b/proto/tendermint/blocksync/message_test.go
@@ -87,7 +87,8 @@ func TestStatusResponse_Validate(t *testing.T) {
 func TestBlockchainMessageVectors(t *testing.T) {
 	coreChainLock := types.NewMockChainLock(1)
 
-	block := types.MakeBlock(int64(3), coreChainLock.CoreBlockHeight, &coreChainLock, []types.Tx{types.Tx("Hello World")}, nil, nil, 0)
+	block := types.MakeBlock(int64(3), []types.Tx{types.Tx("Hello World")}, nil, nil)
+	block.SetDashParams(coreChainLock.CoreBlockHeight, &coreChainLock, 0)
 	block.Version.Block = 11 // overwrite updated protocol version
 
 	bpb, err := block.ToProto()

--- a/types/block.go
+++ b/types/block.go
@@ -348,21 +348,17 @@ func MaxDataBytesNoEvidence(maxBytes int64) int64 {
 // MakeBlock returns a new block with an empty header, except what can be
 // computed from itself.
 // It populates the same set of fields validated by ValidateBasic.
-func MakeBlock(height int64, coreHeight uint32, coreChainLock *CoreChainLock, txs []Tx, lastCommit *Commit,
-	evidence []Evidence, proposedAppVersion uint64) *Block {
+func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
 	block := &Block{
 		Header: Header{
-			Version:               version.Consensus{Block: version.BlockProtocol, App: 0},
-			Height:                height,
-			CoreChainLockedHeight: coreHeight,
-			ProposedAppVersion:    proposedAppVersion,
+			Version: version.Consensus{Block: version.BlockProtocol, App: 0},
+			Height:  height,
 		},
 		Data: Data{
 			Txs: txs,
 		},
-		CoreChainLock: coreChainLock,
-		Evidence:      evidence,
-		LastCommit:    lastCommit,
+		Evidence:   evidence,
+		LastCommit: lastCommit,
 	}
 	block.fillHeader()
 	return block

--- a/types/block_dash.go
+++ b/types/block_dash.go
@@ -1,0 +1,17 @@
+package types
+
+// SetDashParams sets dash's some parameters to a block
+// this method should call if we need to provide specific dash data
+func (b *Block) SetDashParams(
+	lastCoreChainLockedBlockHeight uint32,
+	coreChainLock *CoreChainLock,
+	proposedAppVersion uint64,
+) {
+	if coreChainLock == nil {
+		b.CoreChainLockedHeight = lastCoreChainLockedBlockHeight
+	} else {
+		b.CoreChainLockedHeight = coreChainLock.CoreBlockHeight
+	}
+	b.ProposedAppVersion = proposedAppVersion
+	b.CoreChainLock = coreChainLock
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From this PR I want to begin making small refactoring that can simplify backport. 
This PR reverts a method signature of `MakeBlock` back to initial state, to be compatible with upstream
The goal of this PR is to be compatible with upstream as much as possible.

## What was done?
<!--- Describe your changes in detail -->
Instead of extending original method, there was created a separate method `SetDashParams` to provide these arguments through it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-Test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
