### PR TITLE
fix: don't use genesis last-block-time for a height is equal initial-height

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -313,24 +313,10 @@ func (state State) MakeBlock(
 	// Build base block with block data.
 	block := types.MakeBlock(height, coreChainLockHeight, coreChainLock, txs, commit, evidence, proposedAppVersion)
 
-	// Set time.
-	var timestamp time.Time
-	if height == state.InitialHeight {
-		timestamp = state.LastBlockTime // genesis time
-	} else {
-		currentTime := tmtime.Now()
-		if currentTime.Before(state.LastBlockTime) {
-			// this is weird, propose last block time
-			timestamp = state.LastBlockTime
-		} else {
-			timestamp = currentTime
-		}
-	}
-
 	// Fill rest of header with state data.
 	block.Header.Populate(
 		state.Version.Consensus, state.ChainID,
-		timestamp, state.LastBlockID,
+		tmtime.Now(), state.LastBlockID,
 		state.Validators.Hash(), state.NextValidators.Hash(),
 		state.ConsensusParams.HashConsensusParams(), state.AppHash, state.LastResultsHash,
 		proposerProTxHash,

--- a/internal/state/validation.go
+++ b/internal/state/validation.go
@@ -190,11 +190,9 @@ func validateBlock(state State, block *types.Block) error {
 
 func validateBlockTime(allowedTimeWindow time.Duration, state State, block *types.Block) error {
 	if block.Height == state.InitialHeight {
-		afterLast := state.LastBlockTime.Add(5 * time.Second)
-		beforeLast := state.LastBlockTime.Add(-5 * time.Second)
-		if block.Time.After(afterLast) || block.Time.Before(beforeLast) {
-			return fmt.Errorf("block time %v is out of window [%v, %v]",
-				block.Time, afterLast, beforeLast)
+		if block.Time.Before(state.LastBlockTime) {
+			return fmt.Errorf("block time %v is before last-block-time %v",
+				block.Time, state.LastBlockTime)
 		}
 	} else {
 		// Validate block Time is within a range of current time

--- a/internal/state/validation.go
+++ b/internal/state/validation.go
@@ -144,8 +144,8 @@ func validateBlock(state State, block *types.Block) error {
 
 	case block.Height == state.InitialHeight:
 		genesisTime := state.LastBlockTime
-		if !block.Time.Equal(genesisTime) {
-			return fmt.Errorf("block time %v is not equal to genesis time %v",
+		if block.Time.Before(genesisTime) {
+			return fmt.Errorf("block time %v is before genesis time %v",
 				block.Time,
 				genesisTime,
 			)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The platform team found an issue, where if a block has a height of 1, then block time is taken from genesis

## What was done?
<!--- Describe your changes in detail -->
The behaviour when block time is used last-block-time from genesis doesn't exists in upstream and v0.9-dev. 
The same logic supported for v0.8-dev

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-Test / E2E

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
