### PR TITLE
feat: allow `create-proof-block-range` to be `0`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1201,7 +1201,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		DontAutoPropose:             false,
 		CreateEmptyBlocks:           true,
 		CreateEmptyBlocksInterval:   0 * time.Second,
-		CreateProofBlockRange:       1,
+		CreateProofBlockRange:       0,
 		PeerGossipSleepDuration:     100 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
 		DoubleSignCheckHeight:       int64(0),
@@ -1305,8 +1305,8 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	if cfg.CreateEmptyBlocksInterval < 0 {
 		return errors.New("create-empty-blocks-interval can't be negative")
 	}
-	if cfg.CreateProofBlockRange < 1 {
-		return errors.New("create-proof-block-range must be greater or equal to 1")
+	if cfg.CreateProofBlockRange < 0 {
+		return errors.New("create-proof-block-range must be greater or equal to 0")
 	}
 	if cfg.PeerGossipSleepDuration < 0 {
 		return errors.New("peer-gossip-sleep-duration can't be negative")

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -27,7 +27,7 @@ func assertMempool(txn txNotifier) mempool.Mempool {
 
 func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	baseConfig := configSetup(t)
-	for proofBlockRange := int64(1); proofBlockRange <= 3; proofBlockRange++ {
+	for proofBlockRange := int64(0); proofBlockRange <= 3; proofBlockRange++ {
 		t.Logf("Checking proof block range %d", proofBlockRange)
 		config, err := ResetConfig("consensus_mempool_txs_available_test")
 		require.NoError(t, err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive team requested to add the ability to disable  proof block operation

## What was done?
<!--- Describe your changes in detail -->
Change validation 'create-proof-block-range', allow to set 0 to ignore proof block app hash

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
e2e tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
