### PR TITLE
chore(backport): allow `create-proof-block-range` to be `0`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1073,7 +1073,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
 		CreateEmptyBlocks:           true,
 		CreateEmptyBlocksInterval:   0 * time.Second,
-		CreateProofBlockRange:       1,
+		CreateProofBlockRange:       0,
 		PeerGossipSleepDuration:     100 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
 		DoubleSignCheckHeight:       int64(0),
@@ -1137,8 +1137,8 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	if cfg.CreateEmptyBlocksInterval < 0 {
 		return errors.New("create-empty-blocks-interval can't be negative")
 	}
-	if cfg.CreateProofBlockRange < 1 {
-		return errors.New("create-proof-block-range must be greater or equal to 1")
+	if cfg.CreateProofBlockRange < 0 {
+		return errors.New("create-proof-block-range must be greater or equal to 0")
 	}
 	if cfg.PeerGossipSleepDuration < 0 {
 		return errors.New("peer-gossip-sleep-duration can't be negative")

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -35,7 +35,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	defer cancel()
 
 	baseConfig := configSetup(t)
-	for proofBlockRange := int64(1); proofBlockRange <= 3; proofBlockRange++ {
+	for proofBlockRange := int64(0); proofBlockRange <= 3; proofBlockRange++ {
 		t.Logf("Checking proof block range %d", proofBlockRange)
 		config, err := ResetConfig(t.TempDir(), "consensus_mempool_txs_available_test")
 		require.NoError(t, err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Need to backport PR-444 (allow `create-proof-block-range` to be `0`)

## What was done?
<!--- Describe your changes in detail -->
backported PR-444

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
